### PR TITLE
Preserve multibyte content when saving it on disk.

### DIFF
--- a/elfeed-db.el
+++ b/elfeed-db.el
@@ -283,8 +283,8 @@ Use `elfeed-db-return' to exit early and optionally return data.
         (unless (file-exists-p file)
           (mkdir (file-name-directory file) t)
           (with-temp-file file
-            (set-buffer-multibyte nil)
-            (insert content)))))))
+            (insert content)
+            (set-buffer-multibyte nil)))))))
 
 (defun elfeed-deref-entry (entry)
   "Move ENTRY's content to filesystem storage. Return the entry."


### PR DESCRIPTION
Inserting multibyte string into unibyte buffer results in losing data
for non-ASCII characters, resulting in non-ASCII content being
unreadable.
