### PR TITLE
Kill current buffer when opening previous item.

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -128,6 +128,7 @@
 (defun elfeed-show-prev ()
   "Show the previous item in the elfeed-search buffer."
   (interactive)
+  (elfeed-kill-buffer)
   (with-current-buffer (elfeed-search-buffer)
     (forward-line -2)
     (call-interactively #'elfeed-search-show-entry)))


### PR DESCRIPTION
Otherwise buffers with read items hang around and distract user when he
tries to quit from item buffer to search buffer.
