### PR TITLE
Decode XML buffer before parsing.

### DIFF
--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -97,6 +97,24 @@ is allowed to be relative to now (`elfeed-time-duration')."
     (list (float-time date))
     (t (float-time))))
 
+(defun elfeed-xml-parse-region (&optional beg end buffer parse-dtd parse-ns)
+  "Decode (if needed) and parse XML file. Uses coding system from
+XML encoding declaration."
+  (let ((coding-system nil))
+    (progn
+      (unless beg (setq beg (point-min)))
+      (unless end (setq end (point-max)))
+      (goto-char beg)
+      (if (re-search-forward "<\\?xml.*encoding=\"\\([^\"]+\\)\".*\\?>" nil t)
+          (setq coding-system
+                (ignore-errors (check-coding-system
+                                (intern (downcase (match-string 1)))))))
+      (when coding-system
+        (setq end (+ beg
+                     (decode-coding-region beg end coding-system))))
+      (goto-char beg)))
+    (xml-parse-region beg end buffer parse-dtd parse-ns))
+
 (provide 'elfeed-lib)
 
 ;; Local Variables:

--- a/elfeed.el
+++ b/elfeed.el
@@ -219,7 +219,7 @@ NIL for unknown."
             (goto-char (point-min))
             (search-forward "\n\n") ; skip HTTP headers
             (set-buffer-multibyte t)
-            (let* ((xml (xml-parse-region (point) (point-max)))
+            (let* ((xml (elfeed-xml-parse-region (point) (point-max)))
                    (entries (case (elfeed-feed-type xml)
                               (:atom (elfeed-entries-from-atom url xml))
                               (:rss (elfeed-entries-from-rss url xml))

--- a/tests/elfeed-lib-tests.el
+++ b/tests/elfeed-lib-tests.el
@@ -62,6 +62,17 @@
     (test "1985-03-24T03:23:42Z"          480482622.0)
     (test "Mon,  5 May 1986 15:16:09 GMT" 515690169.0)))
 
+(ert-deftest elfeed-xml-parse-region ()
+  (with-temp-buffer
+    (insert
+     (encode-coding-string
+      "<?xml version=\"1.0\" encoding=\"windows-1251\"?>
+<title>Тест</title>"
+      'windows-1251))
+    (let ((xml (elfeed-xml-parse-region)))
+      (should (string= "Тест" (nth 2 (nth 0 xml)))))))
+
+
 (provide 'elfeed-lib-tests)
 
 ;;; elfeed-lib-tests.el ends here

--- a/tests/elfeed-tests.el
+++ b/tests/elfeed-tests.el
@@ -144,15 +144,15 @@
   (with-temp-buffer
     (insert elfeed-test-rss)
     (goto-char (point-min))
-    (should (eq (elfeed-feed-type (xml-parse-region)) :rss)))
+    (should (eq (elfeed-feed-type (elfeed-xml-parse-region)) :rss)))
   (with-temp-buffer
     (insert elfeed-test-atom)
     (goto-char (point-min))
-    (should (eq (elfeed-feed-type (xml-parse-region)) :atom)))
+    (should (eq (elfeed-feed-type (elfeed-xml-parse-region)) :atom)))
   (with-temp-buffer
     (insert elfeed-test-rss1.0)
     (goto-char (point-min))
-    (should (eq (elfeed-feed-type (xml-parse-region)) :rss1.0))))
+    (should (eq (elfeed-feed-type (elfeed-xml-parse-region)) :rss1.0))))
 
 (ert-deftest elfeed-entries-from-x ()
   (with-elfeed-test
@@ -160,7 +160,7 @@
       (insert elfeed-test-rss)
       (goto-char (point-min))
       (let ((url (elfeed-test-generate-url))
-            (xml (xml-parse-region)))
+            (xml (elfeed-xml-parse-region)))
         (destructuring-bind (a b) (elfeed-entries-from-rss url xml)
           (should (string= (elfeed-feed-title (elfeed-db-get-feed url))
                            "RSS Title"))
@@ -176,7 +176,7 @@
       (insert elfeed-test-atom)
       (goto-char (point-min))
       (let ((url (elfeed-test-generate-url))
-            (xml (xml-parse-region)))
+            (xml (elfeed-xml-parse-region)))
         (destructuring-bind (a b) (elfeed-entries-from-atom url xml)
           (should (string= (elfeed-feed-title (elfeed-db-get-feed url))
                            "Example Feed"))
@@ -197,7 +197,7 @@
       (insert elfeed-test-rss1.0)
       (goto-char (point-min))
       (let ((url (elfeed-test-generate-url))
-            (xml (xml-parse-region)))
+            (xml (elfeed-xml-parse-region)))
         (destructuring-bind (a b) (elfeed-entries-from-rss1.0 url xml)
           (should (string= (elfeed-feed-title (elfeed-db-get-feed url))
                            "XML.com"))


### PR DESCRIPTION
XML allows to declare document encoding and xml-parse-document doesn't
understand this declaration. To workaround the issue we get coding
system name before parsing, decode the buffer and then pass it to down
to xml-parse-region.
