### PR TITLE
Use non-greedy regex to detect XML encoding

### DIFF
--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -105,7 +105,7 @@ XML encoding declaration."
       (unless beg (setq beg (point-min)))
       (unless end (setq end (point-max)))
       (goto-char beg)
-      (if (re-search-forward "<\\?xml.*encoding=\"\\([^\"]+\\)\".*\\?>" nil t)
+      (if (re-search-forward "<\\?xml.*?encoding=\"\\([^\"]+\\)\".*?\\?>" nil t)
           (setq coding-system
                 (ignore-errors (check-coding-system
                                 (intern (downcase (match-string 1)))))))

--- a/tests/elfeed-lib-tests.el
+++ b/tests/elfeed-lib-tests.el
@@ -70,7 +70,14 @@
 <title>Тест</title>"
       'windows-1251))
     (let ((xml (elfeed-xml-parse-region)))
-      (should (string= "Тест" (nth 2 (nth 0 xml)))))))
+      (should (string= "Тест" (nth 2 (nth 0 xml))))))
+  (with-temp-buffer
+    (insert
+     (concat
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss>"
+      (mapconcat (lambda (i) " ") (number-sequence 1 100000) "")
+      "</rss>"))
+    (elfeed-xml-parse-region)))
 
 
 (provide 'elfeed-lib-tests)


### PR DESCRIPTION
Fixes issue with stack overflow in regexp matcher (#8).
