### PR TITLE
Add elfeed-title-cleanup method

### DIFF
--- a/elfeed.el
+++ b/elfeed.el
@@ -172,7 +172,7 @@ NIL for unknown."
   "Turn parsed Atom content into a list of elfeed-entry structs."
   (let* ((feed-id url)
          (feed (elfeed-db-get-feed feed-id))
-         (title (elfeed-cleanup (xml-query '(feed title *) xml)))
+         (title (elfeed-title-cleanup (xml-query '(feed title *) xml)))
          (autotags (elfeed-feed-autotags url)))
     (setf (elfeed-feed-url feed) url
           (elfeed-feed-title feed) title)
@@ -200,7 +200,7 @@ NIL for unknown."
                               for length = (xml-query '(:length) wrap)
                               collect (list href type length))))
                (elfeed-entry--create
-                :title (elfeed-cleanup title)
+                :title (elfeed-title-cleanup title)
                 :feed-id feed-id
                 :id (cons feed-id (elfeed-cleanup id))
                 :link (elfeed-cleanup link)
@@ -214,7 +214,7 @@ NIL for unknown."
   "Turn parsed RSS content into a list of elfeed-entry structs."
   (let* ((feed-id url)
          (feed (elfeed-db-get-feed feed-id))
-         (title (elfeed-cleanup (xml-query '(rss channel title *) xml)))
+         (title (elfeed-title-cleanup (xml-query '(rss channel title *) xml)))
          (autotags (elfeed-feed-autotags url)))
     (setf (elfeed-feed-url feed) url
           (elfeed-feed-title feed) title)
@@ -237,7 +237,7 @@ NIL for unknown."
                               for length = (xml-query '(:length) wrap)
                               collect (list url type length))))
                (elfeed-entry--create
-                :title (elfeed-cleanup title)
+                :title (elfeed-title-cleanup title)
                 :id full-id
                 :feed-id feed-id
                 :link (elfeed-cleanup link)
@@ -253,7 +253,7 @@ NIL for unknown."
   "Turn parsed RSS 1.0 content into a list of elfeed-entry structs."
   (let* ((feed-id url)
          (feed (elfeed-db-get-feed feed-id))
-         (title (elfeed-cleanup (xml-query '(RDF channel title *) xml)))
+         (title (elfeed-title-cleanup (xml-query '(RDF channel title *) xml)))
          (autotags (elfeed-feed-autotags url)))
     (setf (elfeed-feed-url feed) url
           (elfeed-feed-title feed) title)
@@ -267,7 +267,7 @@ NIL for unknown."
                     (full-id (cons feed-id (elfeed-cleanup id)))
                     (original (elfeed-db-get-entry full-id)))
                (elfeed-entry--create
-                :title (elfeed-cleanup title)
+                :title (elfeed-title-cleanup title)
                 :id full-id
                 :feed-id feed-id
                 :link (elfeed-cleanup link)

--- a/tests/elfeed-lib-tests.el
+++ b/tests/elfeed-lib-tests.el
@@ -56,6 +56,13 @@
   (should (string= (elfeed-cleanup "  foo  bar\n") "foo  bar"))
   (should (string= (elfeed-cleanup "foo\nbar") "foo bar")))
 
+(ert-deftest elfeed-title-cleanup ()
+  (should (string= (elfeed-title-cleanup "  foo  bar\n ") "foo bar"))
+  (should (string= (elfeed-title-cleanup "foo\nbar") "foo bar"))
+  (should (string= (elfeed-title-cleanup "foo&amp;bar") "foo&bar"))
+  (should (string= (elfeed-title-cleanup "foo  &amp;  bar") "foo & bar"))
+  (should (string= (elfeed-title-cleanup "&#8216;test&#8217;") "‘test’")))
+
 (ert-deftest elfeed-float-time ()
   (cl-macrolet ((test (time seconds)
                    `(should (= (elfeed-float-time ,time) ,seconds))))


### PR DESCRIPTION
Adds a method for cleaning up the titles before display to the
user. This includes decoding numeric HTML entities along with a
defcustom alist for user customizable replacements in the form of
elfeed-title-cleanup-replacement-regexps.