### PR TITLE
elfeed-show.el: fix yank to clipboard in OSX

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -170,6 +170,7 @@
   (interactive)
   (let ((link (elfeed-entry-link elfeed-show-entry)))
     (when link
+      (kill-new link)
       (x-set-selection 'PRIMARY link)
       (message "Yanked: %s" link))))
 


### PR DESCRIPTION
While  sexp ''(kill-new link)" is present in function elfeed-search-yank, it is missing from elfeed-show-yank. Pressing y in entry window has not been adding the article URL to the clipboard in OS X. Adding this sexp fixes it.