### PR TITLE
elfeed-search-browse-url: allow generic browser open

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -384,14 +384,19 @@ expression, matching against entry link, title, and feed title."
                collect it into selected
                finally (return (if ignore-region (car selected) selected))))))
 
-(defun elfeed-search-browse-url ()
-  "Visit the current entry in your browser using `browse-url'."
-  (interactive)
+(defun elfeed-search-browse-url (use-generic-p)
+  "Visit the current entry in your browser using `browse-url'.
+
+If there is a prefix argument, visit the current entry in the browser defined by
+  `browse-url-generic-program'."
+  (interactive "P")
   (let ((entries (elfeed-search-selected)))
     (cl-loop for entry in entries
              do (elfeed-untag entry 'unread)
              when (elfeed-entry-link entry)
-             do (browse-url it))
+      do (if use-generic-p
+           (browse-url-generic it)
+           (browse-url it)))
     (mapc #'elfeed-search-update-entry entries)
     (unless (use-region-p) (forward-line))))
 


### PR DESCRIPTION
In response to Issue #83 (feature request), this commit updates
`elfeed-search-browse-url` to use the prefix argument as
`use-generic-p`, which then toggles whether or not `browse-url` or
`browse-url-generic` is used to open the URL in question.

This modification is so that, in the case where user is aware that a
given URL does not render well in the "primary" browser function defined
by `browse-url-browser-function', he/she can opt to use a second browser
-- possibly an external one, such as Chromium -- to open it.