### PR TITLE
adding version number

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -218,8 +218,7 @@ directory and saves all attachments in the chosen directory."
 
 (defun elfeed--download-enclosure (url path)
   "Download asynchronously the enclosure from URL to PATH."
-  (if (fboundp 'async-start)
-      ;; If async is available, don't hang emacs !
+  (if (require 'async nil t)
       (async-start
        (lambda ()
          (url-copy-file url path t))

--- a/elfeed.el
+++ b/elfeed.el
@@ -62,6 +62,10 @@
   "An Emacs web feed reader."
   :group 'comm)
 
+(defconst elfeed-version-string "1.1.2"
+  "The version number of elfeed"
+  )
+
 (defcustom elfeed-feeds ()
   "List of all feeds that Elfeed should follow. You must add your
 feeds to this list.


### PR DESCRIPTION
I'm currently finishing to prepare a sauron module for elfeed. I just need to have a version number in order to validate the load of the module. Do you think it's a good choice to add it  or did you have not add it on purpose ? If it's the first case, I propose to add it this way.