### PR TITLE
elfeed-search.el (elfeed-search-print): Display title with `C-h .`

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -194,7 +194,7 @@ The customization `elfeed-search-date-format' sets the formatting."
                                elfeed-search-title-max-width)
                         :left)))
     (insert (propertize date 'face 'elfeed-search-date-face) " ")
-    (insert (propertize title-column 'face title-faces) " ")
+    (insert (propertize title-column 'face title-faces 'kbd-help title) " ")
     (when feed-title
       (insert (propertize feed-title 'face 'elfeed-search-feed-face) " "))
     (when tags


### PR DESCRIPTION
Add a `kbd-help` property with the full title of the entry in the search view so
it can be displayed with `C-h .`.