### PR TITLE
fix elfeed/search endpoint

### DIFF
--- a/web/elfeed-web.el
+++ b/web/elfeed-web.el
@@ -130,7 +130,7 @@
           (filter (elfeed-search-parse-filter q))
           (count elfeed-web-limit))
      (with-elfeed-db-visit (entry feed)
-       (when (elfeed-search-filter filter entry feed)
+       (when (elfeed-search-filter filter entry feed count)
          (setf (cdr tail) (list entry)
                tail (cdr tail))
          (when (< (cl-decf count) 0)


### PR DESCRIPTION
Not sure if it's right fix, but now `elfeed-search-filter` accepts `count`. And looks like passing `elfeed-web-limit` is the right thing. 

This PR is proposed in order to fix problem with `elfeed-web` when it gets internal server error on search. 