### PR TITLE
Add an elfeed-setup-split-pane function

### DIFF
--- a/elfeed-pkg.el
+++ b/elfeed-pkg.el
@@ -1,3 +1,4 @@
 (define-package "elfeed" "1.3.0"
   "an Emacs Atom/RSS feed reader"
-  '((emacs "24.3")))
+  '((emacs "24.3")
+    (popwin "1.0.0")))

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -146,6 +146,20 @@ Defaults to `elfeed-kill-buffer'.")
       (elfeed-show-refresh))
     (funcall elfeed-show-entry-switch buff)))
 
+(defun elfeed-show-entry--switch-pane (buff)
+  "Display BUFF in a popup window."
+  (popwin:popup-buffer buff
+                       :position 'right
+                       :width 0.5))
+
+(defun elfeed-show-entry--delete-pane ()
+  "Delete the *elfeed-entry* split pane."
+  (interactive)
+  (let* ((buff (get-buffer "*elfeed-entry*"))
+         (window (get-buffer-window buff)))
+    (kill-buffer buff)
+    (delete-window window)))
+
 (defun elfeed-show-next ()
   "Show the next item in the elfeed-search buffer."
   (interactive)

--- a/elfeed.el
+++ b/elfeed.el
@@ -100,6 +100,7 @@ when they are first discovered."
 (provide 'elfeed)
 
 (require 'elfeed-search)
+(require 'elfeed-show)
 (require 'elfeed-lib)
 (require 'elfeed-db)
 
@@ -376,6 +377,13 @@ Only a list of strings will be returned."
   (unless (eq major-mode 'elfeed-search-mode)
     (elfeed-search-mode))
   (elfeed-search-update))
+
+;;;###autoload
+(defun elfeed-setup-split-pane ()
+  "Sets up Elfeed for split pane view."
+  (interactive)
+  (setq elfeed-show-entry-switch #'elfeed-show-entry--switch-pane
+        elfeed-show-entry-delete #'elfeed-show-entry--delete-pane))
 
 ;; New entry filtering
 


### PR DESCRIPTION
This function sets up the `elfeed-show-entry-switch` and `elfeed-show-entry-delete` for a split pane view.

Adds a popwin dependency too, but that's fairly common and thus, shouldn't be an issue.
