### PR TITLE
Customisable elfeed-entry buffer

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -31,6 +31,9 @@ buffer. Does not take any arguments.
 
 Defaults to `elfeed-kill-buffer'.")
 
+(defvar elfeed-show-refresh-function #'elfeed-show-refresh--mail-style
+  "Function called to refresh the `*elfeed-entry*' buffer.")
+
 (defvar elfeed-show-mode-map
   (let ((map (make-sparse-keymap)))
     (prog1 map
@@ -97,8 +100,8 @@ Defaults to `elfeed-kill-buffer'.")
     (setf (url-target obj) nil)
     (url-recreate-url obj)))
 
-(defun elfeed-show-refresh ()
-  "Update the buffer to match the selected entry."
+(defun elfeed-show-refresh--mail-style ()
+  "Update the buffer to match the selected entry, using a mail-style"
   (interactive)
   (let* ((inhibit-read-only t)
          (title (elfeed-entry-title elfeed-show-entry))
@@ -136,6 +139,12 @@ Defaults to `elfeed-kill-buffer'.")
           (insert content))
       (insert (propertize "(empty)\n" 'face 'italic)))
     (goto-char (point-min))))
+
+(defun elfeed-show-refresh ()
+  "Update the buffer to match the selected entry."
+  (interactive)
+
+  (call-interactively elfeed-show-refresh-function))
 
 (defun elfeed-show-entry (entry)
   "Display ENTRY in the current buffer."


### PR DESCRIPTION
Change `elfeed-show-refresh` to call a customisable function. This allows one to override the default, and change the entry buffer contents completely.

This, and `elfeed-show-mode-hook` combined allows one to do stuff like this (via [elfeed-goodies](https://github.com/algernon/elfeed-goodies)):

![screenshot](https://cloud.githubusercontent.com/assets/17243/11563541/c91b2ff0-99d4-11e5-9148-30548ef91d9a.png)
