### PR TITLE
elfeed-search--faces: Search in alist, not tag order

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -276,8 +276,9 @@ The customization `elfeed-search-date-format' sets the formatting."
 
 (defun elfeed-search--faces (tags)
   "Return all the faces that apply to an entry with TAGS."
-  (nconc (cl-loop for tag in tags
-                  append (cdr (assoc tag elfeed-search-face-alist)))
+  (nconc (cl-loop for tag-and-face in elfeed-search-face-alist
+                  if (member (car tag-and-face) tags)
+                  append (cdr tag-and-face))
          (list 'elfeed-search-title-face)))
 
 (defun elfeed-search-print-entry--default (entry)


### PR DESCRIPTION
When searching for faces that match a tag, keep the order of `elfeed-search-face-alist`, instead of the order of the tags on the entry. This allows one to properly apply faces to entries that have tag overlap.

I found myself in a situation where I had tags like `fun`, `9gag`, `comic`, among others. I have feeds tagged `fun` and `comic`, feeds tagged `comic`, and feeds tagged `fun` and `9gag`. Now, I'd like to color 9gag differently than other `fun` tagged feeds, and I want `fun` tagged feeds to have a preference over `comic` tags, when it comes to selecting a face.

So I set a specific order for my `elfeed-search-face-alist`:

```elisp
(setq elfeed-search-face-alist
  '((unread elfeed-search-unread-title-face)
    (9gag algernon/elfeed-9gag-face)
    (fun algernon/elfeed-fun-face)
    (comic algernon/elfeed-comic-face)))
```

But `elfeed-search--faces` was iterating over the tags it received, and the order of the tags had no corellation with my fontification preferences:

```elisp
(elfeed-search--faces '(9gag fun comic)) ;=> 9gag, fun, comic
(elfeed-search--faces '(comic fun 9gag)) ;=> comic, fun, 9gag
```

Instead of this behaviour, I'd rather see the function return the same thing in both cases, and follow the order in `elfeed-search-face-alist`.

The solution in this pull request is obviously slower, as it involves running over (arguably, short) lists a number of times, but I think the length of either list is likely to remain small enough that this should not cause significant slowdowns.

Nevertheless, I'll try my hands at optimising it, and will open a new PR if and when I manage to do so.