### PR TITLE
Autoload bookmark-handler function

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -621,6 +621,7 @@ browser defined by `browse-url-generic-program'."
 
 ;; Bookmarks
 
+;;;###autoload
 (defun elfeed-search-bookmark-handler (record)
   "Jump to an elfeed-search bookmarked location."
   (elfeed)


### PR DESCRIPTION
Now you can jump into elfeed from a saved bookmark without first having
to call `elfeed'.