### PR TITLE
Tolerate entries with non-compliant date formats.

### DIFF
--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -86,10 +86,19 @@ Examples: 2015-02-22, 2015-02, 20150222"
           (when (and (>= year 1900) (< year 2200))
             (float-time (encode-time 0 0 0 day month year t))))))))
 
+(defun elfeed-new-date-for-entry (entry new-date)
+  "Given an existing entry (nil if new) and a new date string,
+decide the entry's current date. Existing entries' dates are
+unchanged if the new date is not parseable. New entries with
+unparseable dates default to the current time."
+  (or (elfeed-float-time new-date)
+      (and entry (elfeed-entry-date entry))
+      (float-time)))
+
 (defun elfeed-float-time (&optional date)
   "Like `float-time' but accept anything reasonable for DATE,
-defaulting to the current time if DATE could not be parsed. Date
-is allowed to be relative to now (`elfeed-time-duration')."
+defaulting to nil if DATE could not be parsed. Date is allowed
+to be relative to now (`elfeed-time-duration')."
   (cl-typecase date
     (string
      (let ((iso-8601 (elfeed-parse-simple-iso-8601 date)))
@@ -100,11 +109,11 @@ is allowed to be relative to now (`elfeed-time-duration')."
                (- (float-time) duration)
              (let ((time (ignore-errors (date-to-time date))))
                (if (equal time '(14445 17280)) ; date-to-time silently failed
-                   (float-time)
+                   nil
                  (float-time time))))))))
     (integer date)
     (list (float-time date))
-    (otherwise (float-time))))
+    (otherwise nil)))
 
 (defun elfeed-xml-parse-region (&optional beg end buffer parse-dtd parse-ns)
   "Decode (if needed) and parse XML file. Uses coding system from

--- a/elfeed.el
+++ b/elfeed.el
@@ -282,9 +282,7 @@ is called for side-effects on the ENTRY object.")
                                :feed-id feed-id
                                :link (elfeed-cleanup link)
                                :tags tags
-                               :date (if (and original (null date))
-                                         (elfeed-entry-date original)
-                                       (elfeed-float-time date))
+                               :date (elfeed-new-date-for-entry original date)
                                :enclosures enclosures
                                :content description
                                :content-type 'html)))
@@ -317,9 +315,7 @@ is called for side-effects on the ENTRY object.")
                                :feed-id feed-id
                                :link (elfeed-cleanup link)
                                :tags tags
-                               :date (if (and original (null date))
-                                         (elfeed-entry-date original)
-                                       (elfeed-float-time date))
+                               :date (elfeed-new-date-for-entry original date)
                                :content description
                                :content-type 'html)))
                (dolist (hook elfeed-new-entry-parse-hook)

--- a/tests/elfeed-lib-tests.el
+++ b/tests/elfeed-lib-tests.el
@@ -63,7 +63,8 @@
     (test "Mon,  5 May 1986 15:16:09 GMT" 515690169.0)
     (test "2015-02-20" 1424390400.0)
     (test "20150220" 1424390400.0)
-    (test "2015-02" 1422748800.0)))
+    (test "2015-02" 1422748800.0)
+    (should (null (elfeed-float-time "notadate")))))
 
 (ert-deftest elfeed-xml-parse-region ()
   (with-temp-buffer


### PR DESCRIPTION
Amazing package. Just tried elfeed for the first time a few days ago and I’m loving it.

I wanted to share and get thoughts on a quick change that made search results more usable for me.

A problem I had shortly after adopting elfeed was with entries containing non-compliant date formats—they would switch to the current time on each update and end up accumulating at the top of my search list, never moving down and out of the way.

To make this case a bit more tolerable, I changed the logic for non-parseable dates as follows:
* New entries will default to the current datetime (elfeed-float-time).
* Existing entries retain their existing date record.

Dates that parse successfully will still update the DB entry if the downloaded date string has changed to something new.

To make this fix easier I changed the behavior of elfeed-float-time (it now returns nil on failure) and added a test to suit. I don't see any negative side-effects from this on my end, but it could easily be done in another function if needed.

I could probably also write an end-to-end test to cover the high-level behavior change here, but wanted to see what you think first. Let me know if I’m missing anything.

Cheers and thanks for the great package!
