### PR TITLE
Load index literally to avoid questioning when size gets to large

### DIFF
--- a/elfeed-db.el
+++ b/elfeed-db.el
@@ -285,7 +285,7 @@ This function increases the size of the structs in the database."
           (plist-put db :entries (make-hash-table :test 'equal))
           ;; Compiler will warn about this (bug#15327):
           (plist-put db :index (avl-tree-create #'elfeed-db-compare)))
-      (with-current-buffer (find-file-noselect index :nowarn)
+      (with-current-buffer (find-file-noselect index :nowarn t)
         (goto-char (point-min))
         (setf elfeed-db (read (current-buffer)))
         (kill-buffer)))


### PR DESCRIPTION
My indexfile is 1.4M at the moment, resulting in the question to open literally or not. Setting this switch prohibits this question.