### PR TITLE
Add missing defcustom keys

### DIFF
--- a/elfeed-curl.el
+++ b/elfeed-curl.el
@@ -25,15 +25,18 @@
 
 (defcustom elfeed-curl-program-name "curl"
   "Name/path by which to invoke the curl program."
-  :group 'elfeed)
+  :group 'elfeed
+  :type 'string)
 
 (defcustom elfeed-curl-max-connections 16
   "Maximum number of concurrent fetches."
-  :group 'elfeed)
+  :group 'elfeed
+  :type 'integer)
 
 (defcustom elfeed-curl-timeout 30
   "Maximum number of seconds a fetch is allowed to take once started."
-  :group 'elfeed)
+  :group 'elfeed
+  :type 'integer)
 
 (defvar elfeed-curl-queue ()
   "List of pending curl requests.")

--- a/elfeed.el
+++ b/elfeed.el
@@ -120,10 +120,14 @@ when they are first discovered."
 (defcustom elfeed-use-curl
   nil ; disabled temporarily for initial release
   ;;(not (null (executable-find elfeed-curl-program-name)))
-  "If non-nil, fetch feeds using curl instead of `url-retrieve'.")
+  "If non-nil, fetch feeds using curl instead of `url-retrieve'."
+  :group 'elfeed
+  :type 'bool)
 
 (defcustom elfeed-user-agent (format "Emacs Elfeed %s" elfeed-version)
-  "User agent string to use for Elfeed (requires `elfeed-use-curl').")
+  "User agent string to use for Elfeed (requires `elfeed-use-curl')."
+  :group 'elfeed
+  :type 'string)
 
 (provide 'elfeed)
 


### PR DESCRIPTION
Patch adds missing defcustom types/groups for curl-related settings.