### PR TITLE
Add endpoint for mark entry as read

### DIFF
--- a/web/elfeed-web.el
+++ b/web/elfeed-web.el
@@ -150,6 +150,19 @@ advanced past it (long poll)."
         (push (httpd-discard-buffer) elfeed-web-waiting)
       (princ (json-encode update-time)))))
 
+(defservlet* elfeed/mark-read application/json (webid)
+  "Mark entry as read"
+  (with-elfeed-web
+   (let ((read-entry (with-elfeed-db-visit (e _)
+		       (when (string= webid (elfeed-web-make-webid e))
+			 (progn
+			   (elfeed-untag e 'unread)
+			   (elfeed-db-return e))))))
+     (if read-entry
+	 (princ (json-encode t))
+       (princ (json-encode '(:error 404)))
+       (httpd-send-header t "application/json" 404)))))
+
 (defservlet* elfeed/mark-all-read application/json ()
   "Marks all entries in the database as read (quick-and-dirty)."
   (with-elfeed-web


### PR DESCRIPTION
Hi!
First, thanks for Elfeed and happy third birthday :-) 

I would like to show you a [mobile version of elfeed](http://github.com/areina/elfeed-cljsrn) that I'm currently developing. I'm open to any comment and I would really appreciate your feedback. 

For the navigation flow in the mobile app, I realized that it is necessary an option to mark an entry as read. I created a new endpoint for this, but I have some doubts that I would like to comment with you:
* This endpoint marks an entry as read searching by id. This is fine now, but probably in the future would be useful mark searching by tag or by feed. 
* I can't put the webid param in the url because it could contain a "/", so it should go as a query param.
* I'm not sure if `with-elfeed-db-visit` and `elfeed-db-return` is the efficient way to implement this. Would be nice if you can confirm it.

Thank you!