### PR TITLE
Allow user apply autotags to all entries with the latest rules easily

### DIFF
--- a/elfeed.el
+++ b/elfeed.el
@@ -576,6 +576,18 @@ Only a list of strings will be returned."
     (customize-save-variable 'elfeed-feeds elfeed-feeds))
   (elfeed-update-feed url))
 
+(defun elfeed-apply-autotags-all ()
+  "Applay autotags to all entries with the latest rules."
+  (interactive)
+  (let ((entries (cl-loop for entry hash-values of elfeed-db-entries
+                          collect entry)))
+    (dolist (entry entries)
+      (when (elfeed-entry-date entry)
+        (let ((feed (elfeed-entry-feed-id entry)))
+          (apply #'elfeed-tag entry (elfeed-feed-autotags feed))
+          )))
+    (message "Apply autotags for all entries done")))
+
 ;;;###autoload
 (defun elfeed-update ()
   "Update all the feeds in `elfeed-feeds'."


### PR DESCRIPTION
I'm new to elfeed and really like it, thanks for the great work!

At first, I import my feed list to elfeed and it works, then realize elfeed allow user add autotags for each feed, it really cool! But the old entries just keep non-tags as before, and I don't want to delete the database so wrote a patch to do such work. Wish it helps for others~