### PR TITLE
Use run-mode-hooks in show- and search-mode.

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -192,7 +192,7 @@ When live editing the filter, it is bound to :live.")
   (add-hook 'elfeed-update-init-hooks #'elfeed-search-update--force)
   (add-hook 'kill-buffer-hook #'elfeed-db-save t t)
   (elfeed-search-update :force)
-  (run-hooks 'elfeed-search-mode-hook))
+  (run-mode-hooks 'elfeed-search-mode-hook))
 
 (defun elfeed-search-buffer ()
   (get-buffer-create "*elfeed-search*"))

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -77,7 +77,7 @@ Defaults to `elfeed-kill-buffer'.")
         buffer-read-only t)
   (buffer-disable-undo)
   (make-local-variable 'elfeed-show-entry)
-  (run-hooks 'elfeed-show-mode-hook))
+  (run-mode-hooks 'elfeed-show-mode-hook))
 
 (defun elfeed-insert-html (html &optional base-url)
   "Converted HTML markup to a propertized string."


### PR DESCRIPTION
Since Elfeed rolls its own major modes instead of using `define-derived-mode`, it runs its own hooks manually using `run-hooks`.

However, `define-derived-mode` uses `run-mode-hook`, not `run-hooks`. As a consequence,  Elfeed's major modes do not currently run the universal `change-major-mode-after-body-hook` and `after-change-major-mode-hook`, which some packages rely on to detect major mode changes.

This PR replaces `run-hooks` with `run-mode-hooks` in `elfeed-search-mode` and `elfeed-show-mode` to resolve this issue.

I don't know what the original rationale was for using the regular `run-hooks`, so please feel free to reject this if there is a good reason!