### PR TITLE
Emms update

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -379,8 +379,18 @@ If ENCLOSURE-INDEX is nil ask for the enclosure number."
                                "Enclosure to play" entry)))
          (url-enclosure (car (elt (elfeed-entry-enclosures entry)
                                   (- enclosure-index 1)))))
-    (with-no-warnings ;; due to lazy require
-      (emms-play-url url-enclosure))))
+    (with-no-warnings ;; due to lazy (require )
+      (with-current-emms-playlist
+	(let ((old-pos (point-max)))
+	  (emms-add-url url-enclosure)
+	  (goto-char old-pos)
+	  ;; if we're sitting on a group name, move forward
+	  (unless (emms-playlist-track-at (point))
+	    (emms-playlist-next))
+	  (emms-playlist-select (point)))
+	;; FIXME: is there a better way of doing this?
+	(emms-stop)
+	(emms-start)))))
 
 (provide 'elfeed-show)
 

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -63,6 +63,7 @@ Defaults to `elfeed-kill-buffer'.")
       (define-key map "\e\t" 'shr-previous-link)
       (define-key map [backtab] 'shr-previous-link)
       (define-key map [mouse-2] 'shr-browse-url)
+      (define-key map "A" 'elfeed-show-add-enclosure-to-playlist)
       (define-key map "P" 'elfeed-show-play-enclosure)))
   "Keymap for `elfeed-show-mode'.")
 
@@ -391,6 +392,22 @@ If ENCLOSURE-INDEX is nil ask for the enclosure number."
 	;; FIXME: is there a better way of doing this?
 	(emms-stop)
 	(emms-start)))))
+
+
+(defun elfeed-show-add-enclosure-to-playlist (&optional entry enclosure-index)
+  "Play enclosure number ENCLOSURE-INDEX from ENTRY using emms.
+If ENTRY is nil use the elfeed-show-entry variable.
+If ENCLOSURE-INDEX is nil ask for the enclosure number."
+  (interactive)
+  (require 'emms) ;; optional
+  (let* ((entry (or entry elfeed-show-entry))
+         (enclosure-index (or enclosure-index
+                              (elfeed--get-enclosure-num
+                               "Enclosure to add" entry)))
+         (url-enclosure (car (elt (elfeed-entry-enclosures entry)
+                                  (- enclosure-index 1)))))
+    (with-no-warnings ;; due to lazy (require )
+      (emms-add-url url-enclosure))))
 
 (provide 'elfeed-show)
 


### PR DESCRIPTION
Hello,

it is a minor update, but I realise that emms-play-url is actualling cleaning the playlist before adding the track. Therefore I added a small hack based on emms-browser-add-tracks-and-play which consists of
appending the stream to the playlist and play it. The second commit is also adding support to just add the enclosure at the end of the playlist.