### PR TITLE
Use hard-coded list instead of dynamic discovery

### DIFF
--- a/elfeed-link.el
+++ b/elfeed-link.el
@@ -34,9 +34,8 @@ of available props."
                         (car (elfeed-entry-id elfeed-show-entry))
                         (cdr (elfeed-entry-id elfeed-show-entry)))
           :description (elfeed-entry-title elfeed-show-entry)
-           (cl-loop for (prop) in (cdr (plist-get
-                                        (symbol-plist 'elfeed-entry)
-                                        'cl-struct-slots))
+           (cl-loop for prop in
+                    (list 'id 'title 'link 'date 'content 'content-type 'enclosures 'tags 'feed-id 'meta)
                     nconc (list
                            (intern (concat ":elfeed-entry-" (symbol-name prop)))
                            (funcall


### PR DESCRIPTION
Because of the internal changes in Emacs cl implementation the "introspection" I've used to get the list of properties of the structure stopped working in Emacs 25.2+

I think it's not worth the effort to support multiple Emacs versions/cl implementations so I've just replaced the reflection with a static list.  Given how stable the elfeed data structures are there should never be a need to change the code very much.