### PR TITLE
Fix: (elfeed-search-set-filter) Treat empty string as nil

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -566,7 +566,9 @@ expression, matching against entry link, title, and feed title."
             (if current-prefix-arg "" elfeed-search-filter)))))
   (with-current-buffer (elfeed-search-buffer)
     (setf elfeed-search-filter
-          (or new-filter (default-value 'elfeed-search-filter)))
+          (or (unless (string-empty-p new-filter)
+                new-filter)
+              (default-value 'elfeed-search-filter)))
     (elfeed-search-update :force)))
 
 (defun elfeed-search--update-list ()


### PR DESCRIPTION
The docstring says that, when the new filter is nil, it will be reset to the default value, but when called interactively, if the user entered an empty filter string, the empty string prevented the default filter from being restored.