### PR TITLE
Autoload all of elfeed-link

### DIFF
--- a/elfeed-link.el
+++ b/elfeed-link.el
@@ -16,6 +16,7 @@
 (require 'elfeed-show)
 (require 'elfeed-search)
 
+;;;###autoload
 (defun elfeed-link-store-link ()
   "Store a link to an elfeed search or entry buffer.
 
@@ -44,6 +45,7 @@ of available props."
                             (intern (concat "elfeed-entry-" (symbol-name prop)))
                             elfeed-show-entry)))))))
 
+;;;###autoload
 (defun elfeed-link-open (filter-or-id)
   "Jump to an elfeed entry or search.
 
@@ -56,20 +58,18 @@ search buffer or show a concrete entry."
     (elfeed)
     (elfeed-search-set-filter filter-or-id)))
 
-;; Register Elfeed with Org
-(if (version< (org-version) "9.0")
+;;;###autoload
+(with-eval-after-load 'org
+  (if (version< (org-version) "9.0")
+      (with-no-warnings
+        (org-add-link-type "elfeed" #'elfeed-link-open)
+        (add-hook 'org-store-link-functions #'elfeed-link-store-link))
     (with-no-warnings
-      (org-add-link-type "elfeed" #'elfeed-link-open)
-      (add-hook 'org-store-link-functions #'elfeed-link-store-link))
-  (with-no-warnings
-    (org-link-set-parameters
-     "elfeed"
-     :follow #'elfeed-link-open
-     :store #'elfeed-link-store-link)))
+      (org-link-set-parameters
+       "elfeed"
+       :follow #'elfeed-link-open
+       :store #'elfeed-link-store-link))))
 
 (provide 'elfeed-link)
-
-;;;###autoload
-(eval-after-load 'org '(require 'elfeed-link))
 
 ;;; elfeed-link.el ends here


### PR DESCRIPTION
Due to the fix for #208, elfeed gets loaded after org-mode. I use org-mode extensively but do not use elfeed-link at all, and I don't want elfeed to be loaded in those situations. This provides an alternative solution to #208 that does not force elfeed to be loaded after org-mode. Instead, it binds autoloads to the functions that org-mode would invoke. I tested an elfeed link to confirm that elfeed would actually get loaded if you attempted to open the link.