### PR TITLE
Allow the user to configure filenames for enclosures

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -252,6 +252,10 @@ directory and saves all attachments in the chosen directory."
   :type 'boolean
   :group 'elfeed)
 
+
+(defvar elfeed-show-enclosure-filename-function #'elfeed-show-enclosure-filename-remote
+  "Function called to generate the filename for an enclosure.")
+
 (defun elfeed--download-enclosure (url path)
   "Download asynchronously the enclosure from URL to PATH."
   (if (require 'async nil :noerror)
@@ -299,6 +303,13 @@ corresponding string."
     (if (file-directory-p fpath)
         fpath)))
 
+(defun elfeed-show-enclosure-filename-remote (entry url-enclosure)
+  "Returns the remote filename as local filename for an enclosure."
+  (file-name-nondirectory
+   (url-unhex-string
+    (car (url-path-and-query (url-generic-parse-url
+			      url-enclosure))))))
+
 (defun elfeed-show-save-enclosure-single (&optional entry enclosure-index)
   "Save enclosure number ENCLOSURE-INDEX from ENTRY.
 If ENTRY is nil use the elfeed-show-entry variable.
@@ -311,10 +322,8 @@ If ENCLOSURE-INDEX is nil ask for the enclosure number."
                                "Enclosure to save" entry)))
          (url-enclosure (car (elt (elfeed-entry-enclosures entry)
                                   (- enclosure-index 1))))
-         (fname (file-name-nondirectory
-                 (url-unhex-string
-                  (car (url-path-and-query (url-generic-parse-url
-                                            url-enclosure))))))
+         (fname
+	  (funcall elfeed-show-enclosure-filename-function entry url-enclosure))
          (retry t)
          (fpath))
     (while retry
@@ -345,10 +354,8 @@ enclosures, but as this is the default, you may not need it."
           (dolist (enclosure-index attachnums)
             (let* ((url-enclosure
                     (aref (elfeed-entry-enclosures entry) enclosure-index))
-                   (fname (file-name-nondirectory
-                           (url-unhex-string
-                            (car (url-path-and-query
-                                  (url-generic-parse-url url-enclosure))))))
+		   (fname
+		    (funcall elfeed-show-enclosure-filename-function entry url-enclosure))
                    (retry t))
               (while retry
                 (setf fpath (expand-file-name (concat attachdir fname) path)


### PR DESCRIPTION
I needed a little bit more control how to name my downloaded podcasts. This allows users to provide their own functions to generate a default filename for enclosures, for example https://gist.github.com/mdom/f2979b7d55b0321439c54761e6277d5c

What do you think?

Cheers, Mario