### PR TITLE
Mostly working prototype of a feed summary screen (FEEDBACK REQUESTED)

### DIFF
--- a/elfeed-summary.el
+++ b/elfeed-summary.el
@@ -1,0 +1,152 @@
+;;; elfeed-search.el --- list feed entries -*- lexical-binding: t; -*-
+
+;; This is free and unencumbered software released into the public domain.
+
+;; Sketch of a summary mode for elfeed, based on a conversation here:
+;; https://www.reddit.com/r/emacs/comments/8y9ikh/elfeed_summarymetasearch_view
+
+;;; Code:
+
+(require 'elfeed-search)
+
+(defcustom elfeed-summary-sort-key "TITLE"
+  "TOTAL, UNREAD, DATE, or TITLE"
+  :group 'elfeed
+  :type 'string)
+
+(defcustom elfeed-summary-line-format "%11s %-70s %s/%s"
+  "Controls summary columns: date, title, unread/total"
+  :group 'elfeed
+  :type 'string)
+
+(defcustom elfeed-summary-date-format '("%Y-%m-%d" 10 :left)
+  "The `format-time-string' format, target width, and alignment for dates.
+
+This should be (string integer keyword) for (format width alignment).
+Possible alignments are :left and :right."
+  :group 'elfeed
+  :type '(list string integer (choice (const :left) (const :right))))
+
+(defface elfeed-summary-title-face
+  '((t :inherit 'elfeed-search-title-face))
+  "Face for showing Elfeed summary titles."
+  :group 'elfeed)
+
+(defface elfeed-summary-date-face
+  '((t :inherit 'elfeed-search-date-face))
+  "Face for showing Elfeed summary dates."
+  :group 'elfeed)
+
+(defface elfeed-summary-unread-count-face
+  '((t :inherit elfeed-search-unread-count-face))
+  "Face for showing Elfeed summary counts."
+  :group 'elfeed)
+
+(defalias 'elfeed-summary-format-date #'elfeed-search-format-date)
+
+(defun elfeed-gather-summary ()
+  (let ((table (make-hash-table :test 'eq)))
+    ;; Stuff all the feeds we care about in a table
+    ;; Each entry is (total-count unread-count most-recent-entry)
+    (dolist (url (elfeed-feed-list))
+      (setf (gethash (elfeed-db-get-feed url) table)
+            (list 0 0 nil)))
+
+    ;; Visit every database entry efficiently ordered by time, descending
+    (with-elfeed-db-visit (entry feed)
+      (let ((info (gethash feed table)))
+        (when info
+          (when (= 1 (cl-incf (car info)))
+            (setf (caddr info) entry))
+          (when (memq 'unread (elfeed-entry-tags entry))
+            (cl-incf (cadr info))))))
+
+    ;; Create a table of the results
+    (cl-loop for feed being the hash-keys of table
+             using (hash-values info)
+             for (total unread most-recent) = info
+                 for title = (or (elfeed-feed-title feed) "<no-title>")
+		 for date = (when most-recent
+			      (elfeed-summary-format-date (elfeed-entry-date most-recent)))
+	         if (> unread 0)
+		 collect (list
+			  :feedid (elfeed-feed-id feed)
+			  :title title
+                          :total total
+                          :unread unread
+                          :date date)
+		 into items
+		 finally return (elfeed-summary-sort! items))))
+
+(defun elfeed-summary-sort! (items)
+   (cl-sort items
+	    (cond ((equal elfeed-summary-sort-key "DATE") #'string<)
+		  ((equal elfeed-summary-sort-key "TOTAL") #'<)
+		  ((equal elfeed-summary-sort-key "UNREAD") #'<)
+		  ((equal elfeed-summary-sort-key "TITLE") #'string<)
+		  (t (error "elfeed-summary-sort-key must be DATE, TOTAL, UNREAD, or TITLE")))
+	    :key (lambda (x) (plist-get x elfeed-summary-sort-key))))
+
+(defun elfeed-summary-quit-window ()
+  "Close the elfeed summary window."
+  (interactive)
+  (quit-window))
+
+(defun elfeed-summary-selected-feed ()
+  "Locate the feedid hidden in the text property of the current line"
+  (plist-get (text-properties-at (point)) 'feedid))
+
+(defun elfeed-summary-show-entry ()
+  "Display the currently selected item in a buffer."
+  (interactive)
+  (message "hi")
+  (let ((feedid (elfeed-summary-selected-feed)))
+    (when feedid
+      (call-interactively #'elfeed)
+      (elfeed-search-set-filter (concat "+unread =" feedid)))))
+
+(defvar elfeed-summary-mode-map
+  (let ((map (make-sparse-keymap)))
+    (prog1 map
+      (suppress-keymap map)
+      (define-key map "q" 'elfeed-summary-quit-window)
+      (define-key map (kbd "RET") 'elfeed-summary-show-entry)
+      (define-key map "n" 'next-line)
+      (define-key map "p" 'previous-line)
+      ;;
+      ;; TODO: command to force update all feeds
+      ;; TODO: command to force update current feed
+      ;; TODO: command to mark all of current feed up to date
+      ;;
+  "Keymap for elfeed-summary-mode.")))
+
+(defun elfeed-summary-mode ()
+  "Major mode for summarizing elfeed feeds.
+\\{elfeed-summary-mode-map}"
+  ;; TODO do any hooks make sense?
+  (interactive)
+  (with-current-buffer (get-buffer-create "*elfeed-summary*")
+    (kill-all-local-variables)
+    (use-local-map elfeed-summary-mode-map)
+    (setq major-mode 'elfeed-summary-mode
+          mode-name "elfeed-summary"
+          header-line-format (format elfeed-summary-line-format "Date" "Title" "Unread" "Total")
+          truncate-lines t
+          buffer-read-only t)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (hl-line-mode)
+      (dolist (item (elfeed-gather-summary))
+;	(let ((line (format elfeed-summary-line-format
+	(let ((line (concat ;;elfeed-summary-line-format
+			    (propertize (plist-get item :date) 'face 'font-lock-keyword-face) ;elfeed-search-date-face)
+			    (propertize (plist-get item :title) 'face 'elfeed-search-title-face)
+			    (propertize (int-to-string (plist-get item  :unread)) 'face 'elfeed-search-title-face) ; 'elfeed-summary-unread-count-face)
+			    (propertize (int-to-string (plist-get item :total)) 'face 'elfeed-search-unread-count-face))))
+	  ;; A little trick here: add a property field holding the feed ID.
+	  (insert (propertize line 'face 'elfeed-search-title-face 'feedid (plist-get item :feedid)))
+	  (insert "\n")))
+      (insert "End of summary.\n")
+      (pop-to-buffer (current-buffer))
+      (setf (point) (point-min)))
+  (buffer-disable-undo)))

--- a/elfeed-summary.el
+++ b/elfeed-summary.el
@@ -167,3 +167,7 @@ Possible alignments are :left and :right."
   (buffer-disable-undo)
   (hl-line-mode)
   (elfeed-summary-update))
+
+(provide 'elfeed-summary)
+
+;;; elfeed-summary.el ends here

--- a/elfeed.el
+++ b/elfeed.el
@@ -72,6 +72,14 @@ Each function should accept no arguments, and return a string or nil."
              elfeed-get-url-at-point
              elfeed-clipboard-get))
 
+(defcustom elfeed-summary-as-default t
+  "If non-nil, top level `elfeed' goes to feed summary page, then
+selecting a feed will take you to the search page; quitting search
+will return you to the feed summary page.  If nil, top level
+`elfeed' takes you to search page."
+  :group 'elfeed
+  :type 'boolean)
+
 (defcustom elfeed-use-curl
   (not (null (executable-find elfeed-curl-program-name)))
   "If non-nil, fetch feeds using curl instead of `url-retrieve'."
@@ -516,6 +524,12 @@ called interactively, SAVE is set to t."
     (customize-save-variable 'elfeed-feeds elfeed-feeds))
   (elfeed-update-feed url))
 
+(defun elfeed-enter (buffer modename)
+  "Jump to showing given BUFFER with MODENAME"
+  (switch-to-buffer buffer)
+  (unless (eq major-mode modename)
+    (funcall (symbol-function modename))))
+
 ;;;###autoload
 (defun elfeed-update ()
   "Update all the feeds in `elfeed-feeds'."
@@ -531,9 +545,9 @@ called interactively, SAVE is set to t."
 (defun elfeed ()
   "Enter elfeed."
   (interactive)
-  (switch-to-buffer (elfeed-search-buffer))
-  (unless (eq major-mode 'elfeed-search-mode)
-    (elfeed-search-mode)))
+  (if elfeed-summary-as-default
+      (elfeed-enter (elfeed-summary-buffer) 'elfeed-summary-mode)
+    (elfeed-enter (elfeed-search-buffer) 'elfeed-search-mode)))
 
 ;; New entry filtering
 
@@ -637,6 +651,7 @@ saved to your customization file."
   (unless byte-compile-root-dir
     (require 'elfeed-csv)
     (require 'elfeed-show)
+    (require 'elfeed-summary)
     (require 'elfeed-search)))
 
 ;;; elfeed.el ends here

--- a/elfeed.el
+++ b/elfeed.el
@@ -72,7 +72,7 @@ Each function should accept no arguments, and return a string or nil."
              elfeed-get-url-at-point
              elfeed-clipboard-get))
 
-(defcustom elfeed-summary-as-default t
+(defcustom elfeed-summary-as-default nil
   "If non-nil, top level `elfeed' goes to feed summary page, then
 selecting a feed will take you to the search page; quitting search
 will return you to the feed summary page.  If nil, top level


### PR DESCRIPTION
Sketch based on reddit conversation with @skeeto for a feed summary that shows you a screen by feed (with counts and dates) instead of by article.

I've hooked into the toplevel elfeed using a defcustom `elfeed-summary-as-top-level`, such that if `t`, you get a selection flow like this:

```
"work" ---(M-x elfeed)---> feed summary ---(Ret)---> search ---(Ret)---> article/entry
```
and then a reverse flow popping back up
```
"back to work"  <---(Q)--- feed summary <---(Q)--- search <---(Q)--- article/entry 
```

 TODO:
   - desktop support?
   - hooks?
   - bookmarks support?
   - user might want to configure columns