### PR TITLE
Refactor enclosure handling.

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -396,45 +396,31 @@ offer to save a range of enclosures."
       (elfeed-show-save-enclosure-multi)
     (elfeed-show-save-enclosure-single)))
 
-(defun elfeed-show-play-enclosure (&optional entry enclosure-index)
-  "Play enclosure number ENCLOSURE-INDEX from ENTRY using emms.
-If ENTRY is nil use the elfeed-show-entry variable.
-If ENCLOSURE-INDEX is nil ask for the enclosure number."
-  (interactive)
-  (require 'emms) ;; optional
-  (let* ((entry (or entry elfeed-show-entry))
-         (enclosure-index (or enclosure-index
-                              (elfeed--get-enclosure-num
-                               "Enclosure to play" entry)))
-         (url-enclosure (car (elt (elfeed-entry-enclosures entry)
-                                  (- enclosure-index 1)))))
-    (with-no-warnings ;; due to lazy (require)
-      (with-current-emms-playlist
-       (let ((old-pos (point-max)))
-         (emms-add-url url-enclosure)
-         (goto-char old-pos)
-         ;; if we're sitting on a group name, move forward
-         (unless (emms-playlist-track-at (point))
-           (emms-playlist-next))
-         (emms-playlist-select (point)))
-       ;; FIXME: is there a better way of doing this?
-       (emms-stop)
-       (emms-start)))))
+(defun elfeed--enclosure-maybe-prompt-index (entry)
+  "Prompt for an enclosure if there are multiple in ENTRY."
+  (if (= 1 (length (elfeed-entry-enclosures entry)))
+      1
+    (elfeed--get-enclosure-num "Enclosure to play" entry)))
 
-(defun elfeed-show-add-enclosure-to-playlist (&optional entry enclosure-index)
-  "Play enclosure number ENCLOSURE-INDEX from ENTRY using emms.
-If ENTRY is nil use the elfeed-show-entry variable.
-If ENCLOSURE-INDEX is nil ask for the enclosure number."
-  (interactive)
+(defun elfeed-show-play-enclosure (enclosure-index)
+  "Play enclosure number ENCLOSURE-INDEX from current entry using EMMS.
+Prompts for ENCLOSURE-INDEX when called interactively."
+  (interactive (list (elfeed--enclosure-maybe-get-index elfeed-show-entry)))
+  (elfeed-show-add-enclosure-to-playlist enclosure-index)
+  (with-no-warnings
+    (with-current-emms-playlist
+      (emms-playlist-select-last)
+      (emms-playlist-mode-play-current-track))))
+
+(defun elfeed-show-add-enclosure-to-playlist (enclosure-index)
+  "Add enclosure number ENCLOSURE-INDEX to current EMMS playlist.
+Prompts for ENCLOSURE-INDEX when called interactively."
+
+  (interactive (list (elfeed--enclosure-maybe-get-index elfeed-show-entry)))
   (require 'emms) ;; optional
-  (let* ((entry (or entry elfeed-show-entry))
-         (enclosure-index (or enclosure-index
-                              (elfeed--get-enclosure-num
-                               "Enclosure to add" entry)))
-         (url-enclosure (car (elt (elfeed-entry-enclosures entry)
-                                  (- enclosure-index 1)))))
-    (with-no-warnings ;; due to lazy (require )
-      (emms-add-url url-enclosure))))
+  (with-no-warnings ;; due to lazy (require )
+    (emms-add-url   (car (elt (elfeed-entry-enclosures elfeed-show-entry)
+                              (- enclosure-index 1))))))
 
 (defun elfeed-show-next-link ()
   "Skip to the next link, exclusive of the Link header."


### PR DESCRIPTION
This completely rewrites `ELFEED-SHOW-PLAY-ENCLOSURE` and
`ELFEED-SHOW-ADD-ENCLOSURE` so they’re simpler, easier to use, and
don’t duplicate code.

 - If there’s only one enclosure, don’t prompt, just handle it.
 - Use `(interactive)` how it’s intended.  User is (maybe) prompted
   for arguments when it’s called interactively, when called from
   Lisp, the argument must be supplied & the user will never be
   prompted.
 - Remove `entry` argument, only operate on the current entry.
   This could be changed if desired, but it appears to be unused and
   is annoying to make work.
 - `ELFEED-SHOW-PLAY-ENCLOSURE` calls `ELFEED-SHOW-ADD-ENCLOSURE`
   instead of duplicating its code.
 - The FIXME in `ELFEED-SHOW-PLAY-ENCLOSURE` has been fixed.