### PR TITLE
Fix playing when there are multiple tracks on the playlist

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -409,8 +409,9 @@ Prompts for ENCLOSURE-INDEX when called interactively."
   (elfeed-show-add-enclosure-to-playlist enclosure-index)
   (with-no-warnings
     (with-current-emms-playlist
-      (emms-playlist-select-last)
-      (emms-playlist-mode-play-current-track))))
+      (save-excursion
+        (emms-playlist-last)
+        (emms-playlist-mode-play-current-track)))))
 
 (defun elfeed-show-add-enclosure-to-playlist (enclosure-index)
   "Add enclosure number ENCLOSURE-INDEX to current EMMS playlist.


### PR DESCRIPTION
This corrects a bug I introduced in #313.

`EMMS-PLAYLIST-SELECT-LAST` selects a track, but because it’s inside a
`SAVE-EXCURSION` form, point doesn’t move.  This means that when
`EMMS-PLAYLIST-MODE-PLAY-CURRENT-TRACK` runs, it may play a different
track than the one that was just added -- whichever one is under
point, or the next track from that position.  This seems to work with
simple playlists, but fails when you have other things playing or
several entries.

Instead, use `EMMS-PLAYLIST-LAST`, which moves point, and wrap both
forms in `SAVE-EXCURSION` to avoid changing the buffer out from under
the user.