### PR TITLE
Absolute dates + filter with time ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,15 @@ Any component of the search string beginning with a `+` or
 a `-` is treated like a tag. `+` means the tag is required, `-` means
 the tag must not be present.
 
-A component beginning with a `@` indicates an age. Entries older than
-this age are filtered out. The age description accepts plain English,
-but cannot have spaces, so use dashes. For example, `"@2-years-old"`
-or `"@3-days-ago"`. The database is date-oriented, so **filters that
-include an age restriction are significantly more efficient.**
+A component beginning with a `@` indicates an age or a date range. An age is a
+relative time expression or an absolute date expression. Entries older than this
+age are filtered out. The age description accepts plain English, but cannot have
+spaces, so use dashes. For example, `"@2-years-old"`, `"@3-days-ago"` or
+`"@2019-06-24"`. A date range are two ages seperated by a `--`, e.g.
+`"@2019-06-24--2019-06-24"` or `"@5-days-ago--1-day-ago"`. The entry must be
+newer than the first expression but older than the second. The database is
+date-oriented, so **filters that include an age restriction are significantly
+more efficient.**
 
 A component beginning with a `!` is treated as an "inverse" regular
 expression. This means that any entry matching this regular expression

--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -39,11 +39,13 @@
 (defun elfeed-time-duration (time)
   "Turn a time expression into a number of seconds. Uses
 `timer-duration' but allows a bit more flair."
-  (if (numberp time)
-      time
-    (when (string-match-p "[[:alpha:]]" time)
-      (let ((clean (replace-regexp-in-string "\\(ago\\|old\\|-\\)" " " time)))
-        (timer-duration clean)))))
+  (cond
+   ((numberp time) time)
+   ((let ((iso-time (elfeed-parse-simple-iso-8601 time)))
+      (when iso-time (float-time (time-subtract (current-time) iso-time)))))
+   ((string-match-p "[[:alpha:]]" time)
+    (let ((clean (replace-regexp-in-string "\\(ago\\|old\\|-\\)" " " time)))
+      (timer-duration clean)))))
 
 (defun elfeed-looks-like-url-p (string)
   "Return true if STRING looks like it could be a URL."
@@ -77,15 +79,23 @@ Align should be a keyword :left or :right."
 (defun elfeed-parse-simple-iso-8601 (string)
   "Attempt to parse STRING as a simply formatted ISO 8601 date.
 Examples: 2015-02-22, 2015-02, 20150222"
-  (save-match-data
-    (let ((re "^\\([0-9]\\{4\\}\\)-?\\([0-9]\\{2\\}\\)-?\\([0-9]\\{2\\}\\)?$")
-          (clean (elfeed-cleanup string)))
-      (when (string-match re clean)
-        (let ((year (string-to-number (match-string 1 clean)))
-              (month (string-to-number (match-string 2 clean)))
-              (day (string-to-number (or (match-string 3 clean) "1"))))
-          (when (and (>= year 1900) (< year 2200))
-            (float-time (encode-time 0 0 0 day month year t))))))))
+  (let* ((re (cl-flet ((re-numbers (num) (format "\\([0-9]\\{%s\\}\\)" num)))
+	       (format "^%s-?%s-?%s?\\(T%s:%s:?%s?\\)?"
+		       (re-numbers 4)
+		       (re-numbers 2)
+		       (re-numbers 2)
+		       (re-numbers 2)
+		       (re-numbers 2)
+		       (re-numbers 2))))
+	 (matches (save-match-data
+		    (when (string-match re string)
+		      (cl-loop for i from 1 to 7
+			       collect (let ((match (match-string i string)))
+					 (and match (string-to-number match))))))))
+    (when matches
+      (cl-multiple-value-bind (year month day _ hour min sec) matches
+	(float-time (encode-time (or sec 0) (or min 0) (or hour 0)
+				 (or day 1) month year t))))))
 
 (defun elfeed-new-date-for-entry (old-date new-date)
   "Decide entry date, given an existing date (nil for new) and a new date.

--- a/tests/elfeed-lib-tests.el
+++ b/tests/elfeed-lib-tests.el
@@ -24,6 +24,20 @@
   (should (= (elfeed-time-duration "1-day")       (* 1.0 24 60 60)))
   (should (= (elfeed-time-duration "1hour")       (* 1.0 60 60))))
 
+(ert-deftest elfeed-time-duration-absolute ()
+  ;; fixed time for testing: assume U.S. eastern
+  (cl-letf (((symbol-function 'current-time)
+	     (lambda () (encode-time 0 20 13 24 6 2019 (* -1 4 60 60)))))
+    ;; "2019-06-24T13:20:00-04:00" is "2019-06-24T17:20:00Z" so 17h 20mins is
+    ;; the time difference:
+    (should (= (+ (* 17 60 60) (* 20 60)) (elfeed-time-duration "2019-06-24")))
+    (should (= (* 10 60) (elfeed-time-duration "2019-06-24T17:10")))
+    (should (= (* 10 60) (elfeed-time-duration "2019-06-24T17:10:00")))
+    (should (= (+ (* 9 60) 30) (elfeed-time-duration "2019-06-24T17:10:30")))
+    (should (= (+ (* 9 60) 30) (elfeed-time-duration "2019-06-24T17:10:30Z")))
+    (should (= (+ (* 9 60) 30) (elfeed-time-duration "2019-06-24T17:10:30+00:00")))
+    (should (= (+ (* 9 60) 30) (elfeed-time-duration "20190624T17:10:30+00:00")))))
+
 (ert-deftest elfeed-format-column ()
   (should (string= (elfeed-format-column "foo" 10 :right) "       foo"))
   (should (string= (elfeed-format-column "foo" 10 :left)  "foo       "))
@@ -59,6 +73,7 @@
 (ert-deftest elfeed-float-time ()
   (cl-macrolet ((test (time seconds)
                    `(should (= (elfeed-float-time ,time) ,seconds))))
+    (test "1985-03-24"                    480470400.0)
     (test "1985-03-24T03:23:42Z"          480482622.0)
     (test "Mon,  5 May 1986 15:16:09 GMT" 515690169.0)
     (test "2015-02-20" 1424390400.0)

--- a/tests/elfeed-lib-tests.el
+++ b/tests/elfeed-lib-tests.el
@@ -27,7 +27,7 @@
 (ert-deftest elfeed-time-duration-absolute ()
   ;; fixed time for testing: assume U.S. eastern
   (cl-letf (((symbol-function 'current-time)
-	     (lambda () (encode-time 0 20 13 24 6 2019 (* -1 4 60 60)))))
+             (lambda () (encode-time 0 20 13 24 6 2019 (* -1 4 60 60)))))
     ;; "2019-06-24T13:20:00-04:00" is "2019-06-24T17:20:00Z" so 17h 20mins is
     ;; the time difference:
     (should (= (+ (* 17 60 60) (* 20 60)) (elfeed-time-duration "2019-06-24")))

--- a/tests/elfeed-search-tests.el
+++ b/tests/elfeed-search-tests.el
@@ -1,0 +1,57 @@
+;;; elfeed-search-tests.el --- search tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'elfeed-search)
+
+(defmacro test-search-parse-filter-duration (filter after-days &optional before-days)
+  (let ((day (* 24 60 60)))
+    `(should (equal ',(cl-concatenate 'list
+                                      (when before-days
+                                        (list :before (float (* day before-days))))
+                                      (list :after (float (* day after-days))))
+                    (elfeed-search-parse-filter ,filter)))))
+
+(ert-deftest elfeed-parse-filter-time-durations ()
+  (cl-letf (((symbol-function 'current-time)
+             (lambda () (encode-time 0 0 0 24 6 2019 t))))
+    (test-search-parse-filter-duration "@5-days-ago--3-days-ago" 5 3)
+    (test-search-parse-filter-duration "@3-days-ago--5-days-ago" 5 3)
+    (test-search-parse-filter-duration "@2019-06-01" 23)
+    (test-search-parse-filter-duration "@2019-06-20--2019-06-01" 23 4)
+    (test-search-parse-filter-duration "@2019-06-01--2019-06-20" 23 4)
+    (test-search-parse-filter-duration "@2019-06-01--4-days-ago" 23 4)
+    (test-search-parse-filter-duration "@4-days-ago--2019-06-01" 23 4)))
+
+(defmacro run-date-filter (filter entry-time-string test-time-string)
+  "Creates an entry with ENTRY-TIME-STRING, sets the current time
+to TEST-TIME-STRING and then tests the compiled filter function
+by calling it with entry and FILTER. Returns t if the filter
+matches, nil otherwise."
+  `(let* ((test-time (seconds-to-time (elfeed-parse-simple-iso-8601 ,test-time-string)))
+          (entry-time (seconds-to-time (elfeed-parse-simple-iso-8601 ,entry-time-string)))
+          (orig-float-time (symbol-function 'float-time))
+          (entry (elfeed-entry--create
+                  :title "test-entry"
+                  :date (float-time entry-time))))
+     (cl-letf (((symbol-function 'current-time)
+                (lambda () test-time))
+               ((symbol-function 'float-time)
+                (lambda (&optional time) (funcall orig-float-time test-time))))
+       (catch 'elfeed-db-done
+         (let ((filter-fn (elfeed-search-compile-filter (elfeed-search-parse-filter ,filter))))
+           (funcall filter-fn entry nil 0))))))
+
+(ert-deftest elfeed-search-compile-filter ()
+  (should (null (run-date-filter "@1-days-ago"               "2019-06-23" "2019-06-25")))
+  (should       (run-date-filter "@3-days-ago"               "2019-06-23" "2019-06-25"))
+  (should (null (run-date-filter "@30-days-ago--10-days-ago" "2019-06-23" "2019-06-25")))
+  (should       (run-date-filter "@2019-06-01"               "2019-06-23" "2019-06-25"))
+  (should (null (run-date-filter "@2019-06-01--2019-06-20"   "2019-06-23" "2019-06-25"))))
+
+(ert-deftest elfeed-search-unparse-filter ()
+  (should (string-equal "@5-minutes-ago" (elfeed-search-unparse-filter '(:after 300))))
+  (should (string-equal "@5-minutes-ago--1-minute-ago" (elfeed-search-unparse-filter '(:after 300 :before 60)))))
+
+(provide 'elfeed-search-tests)
+
+;;; elfeed-search-tests.el ends here


### PR DESCRIPTION
This allows to specify date/time ranges as well as absolute dates/times in filters as discussed in #305.

Examples for ranges are `"@2019-06-24--2019-06-24"` or `"@5-days-ago--1-day-ago"` with the meaning that entries need to be newer than the first value and older than the second.