### PR TITLE
Refine behavior of "c", "<", and ">" keybindings.

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -582,7 +582,8 @@ Executing a filter in bytecode form is generally faster than
 (defun elfeed-search-clear-filter ()
   "Reset the search filter to the default value of `elfeed-search-filter'."
   (interactive)
-  (setf elfeed-search-filter (default-value 'elfeed-search-filter)))
+  (setf elfeed-search-filter (default-value 'elfeed-search-filter))
+  (elfeed-search-update--force))
 
 (defun elfeed-search-set-filter (new-filter)
   "Set a new search filter for the elfeed-search buffer.

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -107,6 +107,13 @@ When live editing the filter, it is bound to :live.")
   (elfeed-db-save)
   (quit-window))
 
+(defun elfeed-search-last-entry ()
+  (end-of-buffer)
+  (forward-line -2))
+
+(defun elfeed-search-first-entry ()
+  (beginning-of-buffer))
+
 (defvar elfeed-search-mode-map
   (let ((map (make-sparse-keymap)))
     (prog1 map
@@ -127,8 +134,8 @@ When live editing the filter, it is bound to :live.")
       (define-key map "p" #'previous-line)
       (define-key map "+" #'elfeed-search-tag-all)
       (define-key map "-" #'elfeed-search-untag-all)
-      (define-key map "<" #'beginning-of-buffer)
-      (define-key map ">" #'end-of-buffer)))
+      (define-key map "<" #'elfeed-search-first-entry)
+      (define-key map ">" #'elfeed-search-last-entry)))
   "Keymap for elfeed-search-mode.")
 
 (defun elfeed-search--intro-header ()


### PR DESCRIPTION
Make filter clearing update the search view.

Make ">" go to the last RSS article rather than the end of the buffer by backing up two lines.