### PR TITLE
Convert the update time explicitly to float

### DIFF
--- a/web/elfeed-web.el
+++ b/web/elfeed-web.el
@@ -159,7 +159,7 @@
 time parameter is provided don't respond until the time has
 advanced past it (long poll)."
   (let ((update-time (ffloor (elfeed-db-last-update))))
-    (if (= update-time (ffloor (string-to-number (or time ""))))
+    (if (= update-time (ffloor (float (string-to-number (or time "")))))
         (push (httpd-discard-buffer) elfeed-web-waiting)
       (princ (json-encode update-time)))))
 


### PR DESCRIPTION
Since Emacs 26.1 'ffloor' only accepts floating-point arguments.

I got an empty page on when loading `/elfeed`, because of:

```
(request
 (date "Fr,  6 Sep 2019 20:00:07 GMT")
 (address "127.0.0.1")
 (get "/elfeed/update")
 (headers
  ("GET" "/elfeed/update?time=0" "HTTP/1.1")
  ("Host" "localhost:8080")
  ("Connection" "keep-alive")
  ("Accept" "application/json, text/plain, */*")
  ("X-Requested-With" "XMLHttpRequest")
  ("User-Agent" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36")
  ("Sec-Fetch-Mode" "cors")
  ("Sec-Fetch-Site" "same-origin")
  ("Referer" "http://localhost:8080/elfeed/")
  ("Accept-Encoding" "gzip, deflate, br")
  ("Accept-Language" "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7")
  ("Content" "")))
(error 500
       (wrong-type-argument floatp 0))

```