### PR TITLE
Ensure bookmarks are loaded for elfeed-search

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -8,6 +8,7 @@
 (require 'browse-url)
 (require 'wid-edit) ; widget-inactive face
 (require 'bookmark)
+(bookmark-maybe-load-default-file)
 
 (require 'elfeed)
 (require 'elfeed-db)


### PR DESCRIPTION
According to the docstring of bookmark-jump:

  You may have a problem using this function if the value of
  variable ‘bookmark-alist’ is nil. If that happens, you need to
  load in some bookmarks. See help on function ‘bookmark-load’ for
  more about this.

So e.g. binding a key to jump to an elfeed bookmark will cause an
error without first loading bookmarks.