### PR TITLE
Implemented "exclude feed" functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ A component beginning with a `=` is a regular expression matching the
 entry's feed (title or URL). Only entries belonging to a feed that
 match at least one of the `=` expressions will be shown.
 
+A component beginning with a `~` is a regular expression matching the
+entry's feed (title or URL). Only entries belonging to a feed that
+match none of the `~` expressions will be shown.
+
 All other components are treated as a regular expression, and only
 entries matching it (title or URL) will be shown.
 


### PR DESCRIPTION
This allows to specify several feeds to be excluded from the elfeed-search buffer, as discussed in #347.

I have modified 4 functions :
- elfeed-search-parse-filter
- elfeed-search-unparse-filter
- elfeed-search-filter
- elfeed-search-compile-filter

I have simply added a special character ('~') in the first two functions, and added a condition in the last two : similarly to =, if the entry's feed name or id matches **any** the ~-prepended strings, it is excluded.

The modified repo builds correctly (make gives no errors) and passes all the tests (make check is satisfied), although I haven't included any new ones. I have tested the package manually on the new features, though, and it works : the amount of entries with ~%s plus the amount of entries with =%s is always equal to the amount without any filters (tested on a dozen strings).

I hope you find this satisfactory.

Aymeric Agon-Rambosson