### PR TITLE
Log curl args at debug level

### DIFF
--- a/elfeed-curl.el
+++ b/elfeed-curl.el
@@ -435,6 +435,7 @@ results will not."
            (args (elfeed-curl--args url elfeed-curl--token headers method data))
            (process (apply #'start-process "elfeed-curl" (current-buffer)
                            elfeed-curl-program-name args)))
+	  (elfeed-log 'debug "curl args %s" args)
       (prog1 process
         (if (listp url)
             (progn


### PR DESCRIPTION
This has proved valuable to be able to reproduce issues I had calling elfeed-update on the command line.

It will expose the password in the *elfeed-log* buffer so that could be a valid reason to not merge this PR. Or at least not as-is.

FWIW it allowed me to debug and fix this https://github.com/fasheng/elfeed-protocol/pull/34.