### PR TITLE
Add elfeed-entry-other-window function

### DIFF
--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -377,6 +377,22 @@ This includes expanding e.g. 3-5 into 3,4,5.  If the letter
         url
       host)))
 
+(defun elfeed-entry-other-window ()
+  "In elfeed-search mode, open elfeed entry in the other window
+if other window is present, else sensibly splits the frame if
+there is only a single window and opens the elfeed entry in the
+other window."
+
+  (interactive)
+  (if (get-buffer "*elfeed-search*")
+      (progn
+	(split-window-sensibly (selected-window))
+	(switch-to-buffer-other-window "*elfeed-search*")
+	(call-interactively #'elfeed-search-show-entry)
+	(other-window 1)
+	(forward-line))
+    (message "Start elfeed first!")))
+
 (provide 'elfeed-lib)
 
 ;;; elfeed-lib.el ends here


### PR DESCRIPTION
**Thanks a bunch for a wonderful program!**

In elfeed-search mode, this function opens the elfeed entry under point in another window if another window is present, or else sensibly splits the frame if there is only a single window and opens the elfeed entry in the other window. After opening the elfeed entry in the other window, the pointer is
moved down one line in elfeed search. This makes it easier to stay in your elfeed-search buffer and open/parse items without having to go back-and-forth between the elfeed-search buffer and elfeed-entry buffer.

Can be bound to "o" by adding the following to your dot emacs file:
(add-hook 'elfeed-search-mode-hook (lambda () (local-set-key (kbd "o") 'elfeed-entry-other-window)))