### PR TITLE
Advertise support for Atom in HTTP Accept header

### DIFF
--- a/elfeed.el
+++ b/elfeed.el
@@ -177,7 +177,8 @@ of `elfeed-use-curl'."
          (let* ((feed (elfeed-db-get-feed url))
                 (last-modified (elfeed-meta feed :last-modified))
                 (etag (elfeed-meta feed :etag))
-                (headers `(("User-Agent" . ,elfeed-user-agent))))
+                (headers `(("User-Agent" . ,elfeed-user-agent)
+                           ("Accept" . "application/atom+xml"))))
            (when etag
              (push `("If-None-Match" . ,etag) headers))
            (when last-modified


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc7231#section-5.3.2 HTTP clients may
advertise support for content types via the Accept header.

Some HTTP servers that serve Atom require this, e.g. https://developer.github.com/v3/activity/feeds