### PR TITLE
No longer query users about running curl processes

### DIFF
--- a/elfeed-curl.el
+++ b/elfeed-curl.el
@@ -421,6 +421,7 @@ results will not."
                     elfeed-curl--refcount (length url)))
           (push (cons url cb) elfeed-curl--requests)
           (setf elfeed-curl--refcount 1))
+        (set-process-query-on-exit-flag process nil)
         (setf (process-sentinel process) #'elfeed-curl--sentinel)))))
 
 (defun elfeed-curl--request-key (url headers method data)


### PR DESCRIPTION
This is very minor, but I feel users shouldn't be queried about ephemeral processes like the asynchronous instances of `curl` spawned by Elfeed.

If the processes are old, they will probably time out and there is no harm in killing them. If they are young, then the user's plans presumably changed right after calling `elfeed-update`, and a query would only serve as an obstruction.

(You may also wish to call `set-process-sentinel` in the line after the one I added, for consistency.)