### PR TITLE
Rearrange spacer location in -print-entry--default

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -360,12 +360,12 @@ The customization `elfeed-search-date-format' sets the formatting."
                                title-width
                                elfeed-search-title-max-width)
                         :left)))
-    (insert (propertize date 'face 'elfeed-search-date-face) " ")
-    (insert (propertize title-column 'face title-faces 'kbd-help title) " ")
+    (insert (propertize date 'face 'elfeed-search-date-face))
+    (insert " " (propertize title-column 'face title-faces 'kbd-help title))
     (when feed-title
-      (insert (propertize feed-title 'face 'elfeed-search-feed-face) " "))
+      (insert " " (propertize feed-title 'face 'elfeed-search-feed-face)))
     (when tags
-      (insert "(" tags-str ")"))))
+      (insert " (" tags-str ")"))))
 
 (defun elfeed-search-parse-filter (filter)
   "Parse the elements of a search filter into a plist."


### PR DESCRIPTION
By putting the separating space before the optional element(s), not after the obligatory ones, we ensure that in cases where there are no `tags` or `feed-title`, the `*elfeed-search*` buffer does not contain dangling whitespace.

Before change (with trailing whitespace face highlighted in red):
![Screenshot_2021-05-13_-11-19-10](https://user-images.githubusercontent.com/344774/118107563-31d42e00-b3df-11eb-8e47-63af4c7c8ae3.png)


After change:
![Screenshot_2021-05-13_-11-26-02](https://user-images.githubusercontent.com/344774/118107578-36004b80-b3df-11eb-9892-bbc4efd64786.png)



All tests pass after applying the change.