### PR TITLE
Assign `list-buffers-directory` to the search filter

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -652,6 +652,7 @@ expression, matching against entry link, title, and feed title."
   (with-current-buffer (elfeed-search-buffer)
     (setf elfeed-search-filter
           (or new-filter (default-value 'elfeed-search-filter)))
+    (setq list-buffers-directory new-filter)
     (elfeed-search-update :force)))
 
 (defun elfeed-search--update-list ()

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -158,6 +158,7 @@ Called without arguments."
          (feed-title (elfeed-feed-title feed))
          (base (and feed (elfeed-compute-base (elfeed-feed-url feed)))))
     (erase-buffer)
+    (setq list-buffers-directory (elfeed-entry-title elfeed-show-entry))
     (insert (format (propertize "Title: %s\n" 'face 'message-header-name)
                     (propertize title 'face 'message-header-subject)))
     (when elfeed-show-entry-author


### PR DESCRIPTION
This displays the search filter for elfeed-search buffers in
`M-x list-buffers` instead of showing an empty path column.