### PR TITLE
elfeed-curl-retrieve: set default-directory properly

### DIFF
--- a/elfeed-curl.el
+++ b/elfeed-curl.el
@@ -430,7 +430,8 @@ DNS failure in one will cause all to fail, but 4xx and 5xx
 results will not."
   (with-current-buffer (generate-new-buffer " *curl*")
     (setf elfeed-curl--token (elfeed-curl--token))
-    (let* ((coding-system-for-read 'binary)
+    (let* ((default-directory temporary-file-directory)
+           (coding-system-for-read 'binary)
            (process-connection-type nil)
            (args (elfeed-curl--args url elfeed-curl--token headers method data))
            (process (apply #'start-process "elfeed-curl" (current-buffer)


### PR DESCRIPTION
If `default-directory` was deleted by the user when doing other things, it would lead to a `file-missing` error when the user try to retrieve feeds.  Let's bind it to `temporary-file-directory` so that `elfeed-curl-retrieve` will not be directory-dependent anymore.

I personally triggered this bug just now, this fix solves the issue.

This is a very classical pattern, cf. [a question](https://emacs.stackexchange.com/questions/63723/start-process-setting-current-directory-no-such-file-or-directory) I asked months ago, which describes the same symptom.