### PR TITLE
dereference entry content when attaching to org link

### DIFF
--- a/elfeed-link.el
+++ b/elfeed-link.el
@@ -39,13 +39,14 @@ of available props."
                         (car (elfeed-entry-id elfeed-show-entry))
                         (cdr (elfeed-entry-id elfeed-show-entry)))
           :description (elfeed-entry-title elfeed-show-entry)
-           (cl-loop for prop in
-                    (list 'id 'title 'link 'date 'content 'content-type 'enclosures 'tags 'feed-id 'meta)
-                    nconc (list
-                           (intern (concat ":elfeed-entry-" (symbol-name prop)))
-                           (funcall
-                            (intern (concat "elfeed-entry-" (symbol-name prop)))
-                            elfeed-show-entry)))))))
+          :elfeed-entry-content (elfeed-deref (elfeed-entry-content elfeed-show-entry))
+          (cl-loop for prop in
+                   (list 'id 'title 'link 'date 'content-type 'enclosures 'tags 'feed-id 'meta)
+                   nconc (list
+                          (intern (concat ":elfeed-entry-" (symbol-name prop)))
+                          (funcall
+                           (intern (concat "elfeed-entry-" (symbol-name prop)))
+                           elfeed-show-entry)))))))
 
 ;;;###autoload
 (defun elfeed-link-open (filter-or-id)


### PR DESCRIPTION
For elfeed entries like `elfeed-show-entry`, the "content" is actually a reference to the content in db rather than the content itself. Dereferencing it here when creating the link means that an org capture template can use `%:elfeed-entry-content` for the content as one would expect.