### PR TITLE
Clean HTML tags from title

### DIFF
--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -79,8 +79,10 @@ Align should be a keyword :left or :right."
 
 (defun elfeed-cleanup (name)
   "Trim trailing and leading spaces and collapse multiple spaces."
-  (let ((trim (replace-regexp-in-string "[\f\n\r\t\v ]+" " " (or name ""))))
-    (replace-regexp-in-string "^ +\\| +$" "" trim)))
+  (let* ((trim (replace-regexp-in-string "[\f\n\r\t\v ]+" " " (or name "")))
+         (trim (replace-regexp-in-string "^ +\\| +$" "" trim))
+         (trim (replace-regexp-in-string "\\(<[^>]+>\\|&[^;]+;\\)" "" trim)))
+    trim))
 
 (defun elfeed-parse-simple-iso-8601 (string)
   "Attempt to parse STRING as a simply formatted ISO 8601 date.


### PR DESCRIPTION
Remove tags of the form `< ... >` and `& ... ;`.

These tags appear sometimes, for example in Arts & Letters Daily feed. 

Based on some code in #365.