### PR TITLE
Add mode-class property where appropriate

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -206,6 +206,8 @@ When live editing the filter, it is bound to :live.")
                                          'face 'elfeed-search-filter-face)))
                ("")))))))
 
+(put 'elfeed-search-mode 'mode-class 'special)
+
 (defun elfeed-search-mode ()
   "Major mode for listing elfeed feed entries.
 \\{elfeed-search-mode-map}"

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -77,6 +77,8 @@ Called without arguments."
       (define-key map "P" #'elfeed-show-play-enclosure)))
   "Keymap for `elfeed-show-mode'.")
 
+(put 'elfeed-show-mode 'mode-class 'special)
+
 (defun elfeed-show-mode ()
   "Mode for displaying Elfeed feed entries.
 \\{elfeed-show-mode-map}"


### PR DESCRIPTION
This PR adds the property `mode-class` with value `special` to
`elfeed-search-mode` and `elfeed-show-mode`.

According to the elisp docs every "special" mode should have this
property.
