### PR TITLE
Fix bug "emms-playlist-ensure-playlist-buffer: Not an EMMS playlist buffer"

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -440,8 +440,9 @@ offer to save a range of enclosures."
 Prompts for ENCLOSURE-INDEX when called interactively."
   (interactive (list (elfeed--enclosure-maybe-prompt-index elfeed-show-entry)))
   (elfeed-show-add-enclosure-to-playlist enclosure-index)
+  (require 'emms) ;; optional
   (with-no-warnings
-    (with-current-emms-playlist
+    (with-current-buffer emms-playlist-buffer
       (save-excursion
         (emms-playlist-last)
         (emms-playlist-mode-play-current-track)))))


### PR DESCRIPTION
Hello,

this PR aims to solve the bug describe in the title: basically, when one man tries to play the enclosure, an error is spawn indicating that the current playlist is not defined.