### PR TITLE
Add edebug specificatons to almost all defmacros

### DIFF
--- a/elfeed-db.el
+++ b/elfeed-db.el
@@ -236,7 +236,7 @@ BINDS are the bindings for entry and optionally feed around BODY.
 
   (elfeed-db-visit (entry)
     ...)"
-  (declare (indent defun))
+  (declare (indent defun) (debug ((symbolp &optional symbolp) body)))
   `(catch 'elfeed-db-done
      (prog1 nil
        (elfeed-db-ensure)
@@ -274,6 +274,7 @@ The FEED-OR-ID may be a feed struct or a feed ID (url)."
 
 (defmacro elfeed-db-return (&optional value)
   "Use this to exit early and return VALUE from `elfeed-db-visit'."
+  (declare (debug (&optional sexp)))
   `(throw 'elfeed-db-done ,value))
 
 (defun elfeed-db-get-all-tags ()

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -875,7 +875,7 @@ expression, matching against entry link, title, and feed title."
 (defmacro elfeed-save-excursion (&rest body)
   "Like `save-mark-and-excursion' around BODY.
 But keep entry, line and column instead of only point."
-  (declare (indent defun))
+  (declare (indent defun) (debug t))
   (cl-with-gensyms (point-pos mark-pos)
     `(let* ((,point-pos (elfeed--save-position))
             (,mark-pos (cons (when-let* ((m (marker-position (mark-marker))))

--- a/elfeed.el
+++ b/elfeed.el
@@ -226,7 +226,7 @@ USE-CURL is needed since the interpretation depends on if curl is used."
 This macro is anaphoric, with STATUS referring to the status from
 `url-retrieve'/cURL and USE-CURL being the original invoked-value
 of `elfeed-use-curl'."
-  (declare (indent defun))
+  (declare (indent defun) (debug (&define sexp def-body)))
   `(let* ((use-curl elfeed-use-curl) ; capture current value in closure
           (cb (lambda (status) ,@body)))
      (if elfeed-use-curl

--- a/tests/elfeed-db-tests.el
+++ b/tests/elfeed-db-tests.el
@@ -59,7 +59,7 @@
 
 (defmacro with-elfeed-test (&rest body)
   "Run BODY with a fresh, empty database that will be destroyed on exit."
-  (declare (indent defun))
+  (declare (indent defun) (debug t))
   `(let* ((elfeed-db nil)
           (elfeed-db-feeds nil)
           (elfeed-db-entries nil)

--- a/tests/elfeed-search-tests.el
+++ b/tests/elfeed-search-tests.el
@@ -4,6 +4,7 @@
 (require 'elfeed-search)
 
 (defmacro test-search-parse-filter-duration (filter after-days &optional before-days)
+  (declare (debug (stringp numberp &optional numberp)))
   (let ((day (* 24 60 60)))
     `(should (equal ',(cl-concatenate 'list
                                       (when before-days


### PR DESCRIPTION
These declarations make it possible to step through the &body forms of
the macros, as opposed to skipping over them entirely while
edebugging.

I've tested all the specifications I've added, except for `with-elfeed-web` since I don't use elfeed-web. However, that macro only has body forms, so the debug specification is extremely simple.

I also attempted to declare an edebug specification to `xml-query*` and `xml-query-all*`, and I believe it correctly matches the structure given by the docstring of `xml-query-all`, but I didn't notice any difference in behaviour when Edebugging, for valid or invalid input. 

Heres that attempt: 
```elisp
(def-edebug-elem-spec 'xml-query*
  '([&rest &or
	   symbolp
	   xml-query*
	   (vector symbolp stringp &optional stringp)]
    &optional &or keywordp "*"))

(def-edebug-spec xml-query* (xml-query* sexp))
(def-edebug-spec xml-query-all* (xml-query* sexp))
```

`make check` reports that all tests pass.