### PR TITLE
Set Initial Query from URL Query Parameter in Elfeed Web

### DIFF
--- a/web/elfeed.js
+++ b/web/elfeed.js
@@ -19,7 +19,10 @@ function entryFill(entry) {
 }
 
 function SearchCtrl($scope, $http) {
-    $scope.query = INITIAL_QUERY;
+    // Populate query scope with value passed in URL query parameters, if any.
+    var query_via_url = new URLSearchParams(window.location.search).get("q");
+
+    $scope.query = query_via_url || INITIAL_QUERY;
     $scope.busy = false;
     $scope.dirty = true;
 


### PR DESCRIPTION
## What
  - Previously
    - The initial query was hard-coded to `@3-days-ago`
  - Now
    - Set initial query to load entries in elfeed-web via url query parameter, 
      i.e `?q=<custom-initial-query>`

## Illustration
  - Open `<elfeed-url>/elfeed/?q=%2bimportant%20%4030-days-ago` in web browser
  - This sets initial query to `+important @30-days-ago`
  - And loads entries tagged as "important" from >30-days-ago

## Why
  - Simplify customizing initial query to use for loading entries
  - Create browser bookmarks to your standard elfeed filters.
    Especially useful when accessing elfeed web via phone as a web
    app. Reduce unnecessary typing for accessing standard filters.