### PR TITLE
Optional :entry-base-url feed property overrides base URL derivation

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -156,7 +156,9 @@ Called without arguments."
          (type (elfeed-entry-content-type elfeed-show-entry))
          (feed (elfeed-entry-feed elfeed-show-entry))
          (feed-title (elfeed-feed-title feed))
-         (base (and feed (elfeed-compute-base (elfeed-feed-url feed)))))
+         (base (and feed
+                    (or (elfeed-meta feed :entry-base-url)
+                        (elfeed-compute-base (elfeed-feed-url feed))))))
     (erase-buffer)
     (insert (format (propertize "Title: %s\n" 'face 'message-header-name)
                     (propertize title 'face 'message-header-subject)))


### PR DESCRIPTION
Bofore this commit, when displaying entries in
'elfeed-show-refresh--mail-style' a base URL would be inserted that was derived from the feed URL by removing any URL path and query parameters. However, some feeds are hosted on a different domain then the entries they reference. For example, the feed for kottke.org is on 'https://feeds.kottke.org/' while the entries are on just 'https://kottke.org/'.

This commit allows the user to override the derived base url for entries of a feed by specify an altenative base URL in the ':entry-base-url' property on the feed.

An alternative implementation that derived the base URL from the entry URL instead of the feed URL was considered but rejected because the entry URLs are controlled by the feed and following the entry URL from the elfeed UI requires a user action while the base URL for displaying embedded content in the feed data would not. With this solution the user explicitly acknowledges an additional location from which they are comfortable loading embedded content.