### PR TITLE
Fix warnings about unescaped single quotes in docstrings

### DIFF
--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -17,7 +17,7 @@
 (require 'xml)
 
 (defun elfeed-expose (function &rest args)
-  "Return an interactive version of FUNCTION, 'exposing' it to the user."
+  "Return an interactive version of FUNCTION, \\='exposing\\=' it to the user."
   (lambda () (interactive) (apply function args)))
 
 (defun elfeed-goto-line (n)

--- a/elfeed.el
+++ b/elfeed.el
@@ -42,7 +42,7 @@ Items in this list can also be list whose car is the feed URL
 and cdr is a list of symbols to be applied to all discovered
 entries as tags (\"autotags\"). For example,
 
-  (setq elfeed-feeds '(\"http://foo/\"
+  (setq elfeed-feeds \\='(\"http://foo/\"
                        \"http://bar/\"
                        (\"http://baz/\" comic)))
 
@@ -575,14 +575,14 @@ REMOVE.
 Examples,
 
   (elfeed-make-tagger :feed-url \"youtube\\\\.com\"
-                      :add '(video youtube))
+                      :add \\='(video youtube))
 
   (elfeed-make-tagger :before \"1 week ago\"
-                      :remove 'unread)
+                      :remove \\='unread)
 
   (elfeed-make-tagger :feed-url \"example\\\\.com\"
-                      :entry-title '(not \"something interesting\")
-                      :add 'junk)
+                      :entry-title \\='(not \"something interesting\")
+                      :add \\='junk)
 
 The returned function should be added to `elfeed-new-entry-hook'."
   (let ((after-time  (and after  (elfeed-time-duration after)))

--- a/xml-query.el
+++ b/xml-query.el
@@ -86,10 +86,10 @@ A query is a list of matchers.
  - KEYWORD: filters to an attribute value (must be last)
  - * (an asterisk symbol): filters to content strings (must be last)
 
-For example, to find all the 'alternate' link URL in a typical
+For example, to find all the \\='alternate\\=' link URL in a typical
 Atom feed:
 
-  (xml-query-all '(feed entry link [rel \"alternate\"] :href) xml)"
+  (xml-query-all \\='(feed entry link [rel \"alternate\"] :href) xml)"
   (if (null query)
       xml
     (cl-destructuring-bind (matcher . rest) query


### PR DESCRIPTION
Fixes "docstring has wrong usage of unescaped single quotes" warnings during compilation