### PR TITLE
Fix and extend elfeed-link-store-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,48 @@ filter. Emacs automatically persists bookmarks across sessions.
 
 [bm]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Bookmarks.html
 
+## Org-store-link and Org-capture
+
+When `org-store-link` is called from an Elfeed search or an Elfeed
+entry, a link to the serach or entry is stored in Org-mode format.
+
+This link can be inserted into an Org-mode document. If the link is
+openned, the search or entry will be shown in Elfeed.
+
+In addition to the link, `org-store-link` also store some additonnal
+properties. You can access them in an Org-capture template with the
+template expansion `%:keyword`. (`org-store-link` is automatically
+called when you do a capture.)
+
+List of available keywords, when link is stored from an Elfeed search:
+- `type`               : Type of Org-mode link
+- `link`               : Org-mode link to this search, also available
+                         with %a, %A, %l and %L
+- `description`        : The search filter
+
+
+List of available keywords, when link is stored from an Elfeed entry:
+- `type`               : Type of Org-mode link
+- `link`               : Org-mode link to this entry, also available
+                         with %a, %A, %l and %L
+- `title`              : Feed entry title
+- `description`        : Feed entry description, same as title
+- `external-link`      : Feed entry external link
+- `date`               : Date time of the feed entry publication, in
+                         full ISO 8601 format
+- `authors`            : List of feed entry authors names, joint by a
+                         comma
+- `tags`               : List of feed entry tags, in Org-mode tags
+                         format
+- `content`            : Content of the feed entry
+- `feed-title`         : Title of the feed
+- `feed-external-link` : Feed external link
+- `feed-authors`       : List of feed authors names, joint by a comma
+
+If `content` type is HTML, it is automatically embedded into an
+Org-mode HTML quote.
+
+
 ## Metadata Plist
 
 All feed and entry objects have plist where you can store your own

--- a/README.md
+++ b/README.md
@@ -295,29 +295,33 @@ template expansion `%:keyword`. (`org-store-link` is automatically
 called when you do a capture.)
 
 List of available keywords, when link is stored from an Elfeed search:
-- `type`               : Type of Org-mode link
-- `link`               : Org-mode link to this search, also available
-                         with %a, %A, %l and %L
-- `description`        : The search filter
+- `type`        : Type of Org-mode link
+- `link`        : Org-mode link to this search, also available
+                  with %a, %A, %l and %L
+- `description` : The search filter
 
 
 List of available keywords, when link is stored from an Elfeed entry:
-- `type`               : Type of Org-mode link
-- `link`               : Org-mode link to this entry, also available
-                         with %a, %A, %l and %L
-- `title`              : Feed entry title
-- `description`        : Feed entry description, same as title
-- `external-link`      : Feed entry external link
-- `date`               : Date time of the feed entry publication, in
-                         full ISO 8601 format
-- `authors`            : List of feed entry authors names, joint by a
-                         comma
-- `tags`               : List of feed entry tags, in Org-mode tags
-                         format
-- `content`            : Content of the feed entry
-- `feed-title`         : Title of the feed
-- `feed-external-link` : Feed external link
-- `feed-authors`       : List of feed authors names, joint by a comma
+- `type`                    : Type of Org-mode link
+- `link`                    : Org-mode link to this entry, also available
+                              with %a, %A, %l and %L
+- `title`                   : Feed entry title
+- `description`             : Feed entry description, same as title
+- `external-link`           : Feed entry external link
+- `date`                    : Date time of the feed entry publication, in
+                              full ISO 8601 format
+- `date-timestamp`          : Date time of the feed entry publication, in
+                              Org-mode active timestamp format
+- `date-inactive-timestamp` : Date time of the feed entry publication, in
+                              Org-mode inactive timestamp format
+- `authors`                 : List of feed entry authors names, joint by a
+                              comma
+- `tags`                    : List of feed entry tags, in Org-mode tags
+                              format
+- `content`                 : Content of the feed entry
+- `feed-title`              : Title of the feed
+- `feed-external-link`      : Feed external link
+- `feed-authors`            : List of feed authors names, joint by a comma
 
 If `content` type is HTML, it is automatically embedded into an
 Org-mode HTML quote.

--- a/elfeed-link.el
+++ b/elfeed-link.el
@@ -32,20 +32,14 @@ of available props."
           :link (format "elfeed:%s" elfeed-search-filter)
           :description elfeed-search-filter))
         ((derived-mode-p 'elfeed-show-mode)
-         (apply
-          'org-store-link-props
+         (funcall (if (fboundp 'org-link-store-props)
+                      #'org-link-store-props
+                    (with-no-warnings #'org-store-link-props))
           :type "elfeed"
           :link (format "elfeed:%s#%s"
                         (car (elfeed-entry-id elfeed-show-entry))
                         (cdr (elfeed-entry-id elfeed-show-entry)))
-          :description (elfeed-entry-title elfeed-show-entry)
-           (cl-loop for prop in
-                    (list 'id 'title 'link 'date 'content 'content-type 'enclosures 'tags 'feed-id 'meta)
-                    nconc (list
-                           (intern (concat ":elfeed-entry-" (symbol-name prop)))
-                           (funcall
-                            (intern (concat "elfeed-entry-" (symbol-name prop)))
-                            elfeed-show-entry)))))))
+          :description (elfeed-entry-title elfeed-show-entry)))))
 
 ;;;###autoload
 (defun elfeed-link-open (filter-or-id)

--- a/elfeed-link.el
+++ b/elfeed-link.el
@@ -78,7 +78,7 @@ Org-mode HTML quote."
                  "%FT%T"
                  (elfeed-entry-date elfeed-show-entry))
           ;; Concatenate authors names
-          :authors (mapconcat 'identity
+          :authors (mapconcat #'identity
                               ;; Loop on each author and extract its name
                               ;; Authors list get from Elfeed entry's meta
                               (cl-loop for author
@@ -87,12 +87,12 @@ Org-mode HTML quote."
                               ", ") ;; Join names using a comma
           ;; Concatenate tags in Org-mode tags format
           :tags (format ":%s:"
-                        (mapconcat 'symbol-name
+                        (mapconcat #'symbol-name
                                    (elfeed-entry-tags elfeed-show-entry)
                                    ":"))
           ;; Prepare support of different content type, only HTML for now
           :content (pcase (elfeed-entry-content-type elfeed-show-entry)
-                     ('html
+                     (`html
                       ;; Embed the text into Org-mode HTML quote
                       (format
                        "#+BEGIN_EXPORT html\n%s\n#+END_EXPORT"
@@ -100,7 +100,7 @@ Org-mode HTML quote."
           :feed-title (elfeed-feed-title (elfeed-entry-feed elfeed-show-entry))
           :feed-external-link (elfeed-feed-url (elfeed-entry-feed elfeed-show-entry))
           ;; Concatenate feed authors names
-          :feed-authors (mapconcat 'identity
+          :feed-authors (mapconcat #'identity
                                    ;; Loop on each feed author and extract its name
                                    ;; Authors list get from Elfeed feed
                                    (cl-loop for author

--- a/elfeed-link.el
+++ b/elfeed-link.el
@@ -25,29 +25,33 @@ entry metadata. These can be used in the capture templates as
 `%:keyword` expansion.
 
 List of available keywords, when store from an Elfeed search:
-- `type`               : Type of Org-mode link
-- `link`               : Org-mode link to this search, also available
-                         with %a, %A, %l and %L
-- `description`        : The search filter
+- `type`        : Type of Org-mode link
+- `link`        : Org-mode link to this search, also available
+                  with %a, %A, %l and %L
+- `description` : The search filter
 
 
 List of available keywords, when store from an Elfeed entry:
-- `type`               : Type of Org-mode link
-- `link`               : Org-mode link to this entry, also available
-                         with %a, %A, %l and %L
-- `title`              : Feed entry title
-- `description`        : Feed entry description, same as title
-- `external-link`      : Feed entry external link
-- `date`               : Date time of the feed entry publication, in
-                         full ISO 8601 format
-- `authors`            : List of feed entry authors names, joint by a
-                         comma
-- `tags`               : List of feed entry tags, in Org-mode tags
-                         format
-- `content`            : Content of the feed entry
-- `feed-title`         : Title of the feed
-- `feed-external-link` : Feed external link
-- `feed-authors`       : List of feed authors names, joint by a comma
+- `type`                    : Type of Org-mode link
+- `link`                    : Org-mode link to this entry, also available
+                              with %a, %A, %l and %L
+- `title`                   : Feed entry title
+- `description`             : Feed entry description, same as title
+- `external-link`           : Feed entry external link
+- `date`                    : Date time of the feed entry publication, in
+                              full ISO 8601 format
+- `date-timestamp`          : Date time of the feed entry publication, in
+                              Org-mode active timestamp format
+- `date-inactive-timestamp` : Date time of the feed entry publication, in
+                              Org-mode inactive timestamp format
+- `authors`                 : List of feed entry authors names, joint by a
+                              comma
+- `tags`                    : List of feed entry tags, in Org-mode tags
+                              format
+- `content`                 : Content of the feed entry
+- `feed-title`              : Title of the feed
+- `feed-external-link`      : Feed external link
+- `feed-authors`            : List of feed authors names, joint by a comma
 
 If `content` type is HTML, it is automatically embedded into an
 Org-mode HTML quote."

--- a/elfeed-link.el
+++ b/elfeed-link.el
@@ -21,9 +21,36 @@
   "Store a link to an elfeed search or entry buffer.
 
 When storing a link to an entry, automatically extract all the
-entry metadata.  These can be used in the capture templates as
-%:elfeed-entry-<prop>.  See `elfeed-entry--create' for the list
-of available props."
+entry metadata. These can be used in the capture templates as
+`%:keyword` expansion.
+
+List of available keywords, when store from an Elfeed search:
+- `type`               : Type of Org-mode link
+- `link`               : Org-mode link to this search, also available
+                         with %a, %A, %l and %L
+- `description`        : The search filter
+
+
+List of available keywords, when store from an Elfeed entry:
+- `type`               : Type of Org-mode link
+- `link`               : Org-mode link to this entry, also available
+                         with %a, %A, %l and %L
+- `title`              : Feed entry title
+- `description`        : Feed entry description, same as title
+- `external-link`      : Feed entry external link
+- `date`               : Date time of the feed entry publication, in
+                         full ISO 8601 format
+- `authors`            : List of feed entry authors names, joint by a
+                         comma
+- `tags`               : List of feed entry tags, in Org-mode tags
+                         format
+- `content`            : Content of the feed entry
+- `feed-title`         : Title of the feed
+- `feed-external-link` : Feed external link
+- `feed-authors`       : List of feed authors names, joint by a comma
+
+If `content` type is HTML, it is automatically embedded into an
+Org-mode HTML quote."
   (cond ((derived-mode-p 'elfeed-search-mode)
          (funcall (if (fboundp 'org-link-store-props)
                       #'org-link-store-props
@@ -39,7 +66,44 @@ of available props."
           :link (format "elfeed:%s#%s"
                         (car (elfeed-entry-id elfeed-show-entry))
                         (cdr (elfeed-entry-id elfeed-show-entry)))
-          :description (elfeed-entry-title elfeed-show-entry)))))
+          :description (elfeed-entry-title elfeed-show-entry)
+          :title (elfeed-entry-title elfeed-show-entry)
+          :external-link (elfeed-entry-link elfeed-show-entry)
+          ;; Format date to full ISO 8601 format
+          :date (format-time-string
+                 "%FT%T"
+                 (elfeed-entry-date elfeed-show-entry))
+          ;; Concatenate authors names
+          :authors (mapconcat 'identity
+                              ;; Loop on each author and extract its name
+                              ;; Authors list get from Elfeed entry's meta
+                              (cl-loop for author
+                                       in (plist-get (elfeed-entry-meta elfeed-show-entry) :authors)
+                                       collect (plist-get author :name))
+                              ", ") ;; Join names using a comma
+          ;; Concatenate tags in Org-mode tags format
+          :tags (format ":%s:"
+                        (mapconcat 'symbol-name
+                                   (elfeed-entry-tags elfeed-show-entry)
+                                   ":"))
+          ;; Prepare support of different content type, only HTML for now
+          :content (pcase (elfeed-entry-content-type elfeed-show-entry)
+                     ('html
+                      ;; Embed the text into Org-mode HTML quote
+                      (format
+                       "#+BEGIN_EXPORT html\n%s\n#+END_EXPORT"
+                       (elfeed-deref (elfeed-entry-content elfeed-show-entry)))))
+          :feed-title (elfeed-feed-title (elfeed-entry-feed elfeed-show-entry))
+          :feed-external-link (elfeed-feed-url (elfeed-entry-feed elfeed-show-entry))
+          ;; Concatenate feed authors names
+          :feed-authors (mapconcat 'identity
+                                   ;; Loop on each feed author and extract its name
+                                   ;; Authors list get from Elfeed feed
+                                   (cl-loop for author
+                                            in (elfeed-feed-author(elfeed-entry-feed elfeed-show-entry))
+                                            collect (plist-get author :name))
+                                   ", ") ;; Join names using a comma
+          ))))
 
 ;;;###autoload
 (defun elfeed-link-open (filter-or-id)


### PR DESCRIPTION
As described in #532, second message, the actual function `elfeed-link-store-link` have some problems.

First problem, when we store properties from an Elfeed entry,  `elfeed-link-store-link` call `org-store-link-props`. This function is deprecated since Org-mode 9.3. Instead we need to use `org-link-store-props`.

Second problem, the properties passed to the function `org-link-store-props` need to be preprocessed.

The docstring of `org-link-store-props` say:
> The properties are pre-processed by extracting names, addresses and dates.

Third problem, it is not necessary to add a prefix "elfeed-entry-" to custom properties.

This PR:
- Fix the 3 problems described above
- Add some new properties, like authors, external link, feed-title, etc
- Document the compatibility of Elfeed with `org-store-link` and `org-capture` 
- Document all the keywords available in Org-capture template as `%:keyword` template expansion