### PR TITLE
Update `elfeed-enclosure-default-dir` doc string

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -291,9 +291,7 @@ browser defined by `browse-url-generic-program'."
 
 (defcustom elfeed-enclosure-default-dir (expand-file-name "~")
   "Default directory for saving enclosures.
-This can be either a string (a file system path), or a function
-that takes a filename and the mime-type as arguments, and returns
-the enclosure dir."
+This should be a string (a file system path)."
   :type 'directory
   :group 'elfeed
   :safe 'stringp)


### PR DESCRIPTION
The docstring for the [`elfeed-enclosure-default-dir`][0] variable mentions being able to set this to a function.

When I tried to do this  with a `lambda`, or with the following example code, I got errors when trying to download an enclosure:

```
read-file-name: Wrong type argument: stringp, my-elfeed-enclosure-dir
```

Reading the code in [`elfeed-show.el`][1], it looks like it only expects a string. However, my `elisp` is very weak, so I may just be making an obvious mistake here?[^1]

### example code

```emacs-lisp
(defun my-elfeed-enclosure-dir (fname mime-type)
  "Return the directory for saving enclosures based on filename and mime-type."

  (mkdir "/home/my-user/elfeed/" t)
  "/home/my-user/elfeed/")

(setq elfeed-enclosure-default-dir #'my-elfeed-enclosure-dir)
```

[^1]: I did a [search][2] on github and didn't see anyone else setting this as a function

[0]:https://github.com/skeeto/elfeed/blob/a39fb78e34ee25dc8baea83376f929d7c128344f/elfeed-show.el#L293-L296
[1]:https://github.com/skeeto/elfeed/blob/a39fb78e34ee25dc8baea83376f929d7c128344f/elfeed-show.el#L365-L386
[2]:https://github.com/search?q=elfeed-enclosure-default-dir&type=code