### PR TITLE
Fix URL double-wrapping in queue reconsolidation

### DIFF
--- a/elfeed-curl.el
+++ b/elfeed-curl.el
@@ -468,9 +468,13 @@ in the same curl invocation."
         (queue-out ()))
     (dolist (entry queue-in)
       (cl-destructuring-bind (url _ headers method data) entry
-        (let* ((key (elfeed-curl--request-key url headers method data)))
-          (push key keys)
-          (push entry (gethash key table nil)))))
+        (if (listp url)
+            ;; Already-consolidated entry, pass through unchanged to
+            ;; avoid wrapping its URL list in another list layer.
+            (push entry queue-out)
+          (let* ((key (elfeed-curl--request-key url headers method data)))
+            (push key keys)
+            (push entry (gethash key table nil))))))
     (dolist (key (nreverse keys))
       (let ((entry (gethash key table)))
         (when entry


### PR DESCRIPTION
## Summary

When `elfeed-curl--run-queue` reconsolidates the queue (because new entries were enqueued while previously-consolidated entries remained unprocessed due to connection limits), entries that already have list URLs are fed back through `elfeed-curl--queue-consolidate`. Since `elfeed-curl--request-key` returns `nil` for list URLs, these entries get grouped under a `nil` key and then "rotated" again, wrapping the URL list in an additional list layer:

```
("url1" "url2" ...) => (("url1" "url2" ...))
```

When this doubly-wrapped list reaches `elfeed-curl--args` and then `start-process`, the inner lists are passed as command arguments to curl, causing `make-process` to signal `(wrong-type-argument stringp ...)` because it expects strings, not lists.

## Reproduction scenario

1. Many requests with compatible keys are enqueued (e.g. via `elfeed-tube`'s innertube API calls, which all share the same URL, method, headers, and data).
2. `elfeed-curl--run-queue` consolidates them into a single entry with a URL list.
3. The consolidated entry cannot be dispatched immediately because `elfeed-curl-queue-active >= elfeed-curl-max-connections`.
4. Meanwhile, callbacks from other completed requests enqueue new entries, setting `elfeed-curl--run-queue-queued` to `t`.
5. A connection finishes and `elfeed-curl--queue-wrap` calls `elfeed-curl--run-queue`.
6. Because `elfeed-curl--run-queue-queued` is `t`, the queue is reconsolidated—including the already-consolidated entry from step 3.
7. The already-consolidated entry's URL list is wrapped in another layer, producing `(("url1" "url2" ...))` instead of `("url1" "url2" ...)`.
8. This reaches `make-process` and crashes.

## Fix

Detect already-consolidated entries (those whose URL field is already a list) at the start of `elfeed-curl--queue-consolidate` and pass them through to the output queue unchanged, rather than grouping them under a `nil` key and re-rotating them.

## Backtrace

```
Debugger entered--Lisp error: (wrong-type-argument stringp ("https://..."))
  #<subr make-process>(:name "elfeed-curl" :buffer ... :command ("curl" ... ("https://...") ("https://...") ...))
  make-process@with-editor-process-filter(...)
  ...
  start-process("elfeed-curl" ... "curl" ... ("https://...") ("https://...") ...)
  elfeed-curl-retrieve((("https://...") ("https://...") ...) ...)
  elfeed-curl--run-queue()
```