### PR TITLE
Add lexical-binding comment to xml-query.xml

### DIFF
--- a/xml-query.el
+++ b/xml-query.el
@@ -1,4 +1,4 @@
-;;; xml-query.el --- query engine complimenting the xml package
+;;; xml-query.el --- query engine complimenting the xml package  -*- lexical-binding: t; -*-
 
 ;; This is free and unencumbered software released into the public domain.
 


### PR DESCRIPTION
Hi there,

I'm running Emacs 31 and have noticed a warning about a "missing ‘lexical-binding’ cookie" in xml-query.xml.
Emacs 31 makes lexical-binding the default and shows that warning when it's not enabled: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=74145.

Is there a reason why lexical-binding was not active in the file? Is it by design?
I have not found any incompatibilities yet **BUT** I'm not very familiar with the codebase and my elisp-foo is mid-level.

No issues on my machine so far though.

