### PR TITLE
Add elfeed-ai to extensions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ These projects extend Elfeed with additional features:
 * [Elfeed Android interface](https://github.com/areina/elfeed-cljsrn)
   ([Google Play](https://play.google.com/store/apps/details?id=com.elfeedcljsrn))
 * [elfeed-dashboard](https://github.com/Manoj321/elfeed-dashboard)
+* [elfeed-ai](https://github.com/benthamite/elfeed-ai)
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- Add [elfeed-ai](https://github.com/benthamite/elfeed-ai) to the Extensions section of the README

elfeed-ai brings AI-powered relevance scoring to elfeed via gptel. Users describe their interests in natural language, and the package scores each new entry for relevance, with optional AI-generated summaries.

I am the maintainer of this package. I thought some elfeed users may find it useful, but feel free to close this PR if you'd rather not list it.