### PR TITLE
Refactor elfeed-insert-link to only require shr-tag-a instead a full shr-render

### DIFF
--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -16,6 +16,16 @@
 (require 'url-util)
 (require 'xml)
 
+;; Emacs < 27 compatibility
+(if (fboundp 'elfeed-libxml-supported-p)
+    (defalias 'elfeed-libxml-supported-p #'libxml-available-p)
+  (defun elfeed-libxml-supported-p ()
+    "Return non-nil if `libxml-parse-html-region' is available."
+    (with-temp-buffer
+      (insert "<html></html>")
+      (and (fboundp 'libxml-parse-html-region)
+           (not (null (libxml-parse-html-region (point-min) (point-max))))))))
+
 (defun elfeed-expose (function &rest args)
   "Return an interactive version of FUNCTION, \"exposing\" it to the user."
   (lambda () (interactive) (apply function args)))
@@ -211,13 +221,6 @@ XML encoding declaration."
                            (and (string= data (elfeed-slurp file))
                                 (not (string= data (elfeed-slurp file t)))))
                        (delete-file file)))))))))
-
-(defun elfeed-libxml-supported-p ()
-  "Return non-nil if `libxml-parse-html-region' is available."
-  (with-temp-buffer
-    (insert "<html></html>")
-    (and (fboundp 'libxml-parse-html-region)
-         (not (null (libxml-parse-html-region (point-min) (point-max)))))))
 
 (defun elfeed-keyword->symbol (keyword)
   "If a keyword, convert KEYWORD into a plain symbol (remove the colon)."

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -344,6 +344,9 @@ The customization `elfeed-search-date-format' sets the formatting."
   "Print ENTRY to the buffer."
   (let* ((date (elfeed-search-format-date (elfeed-entry-date entry)))
          (title (or (elfeed-meta entry :title) (elfeed-entry-title entry) ""))
+         (title (decode-coding-string title
+                                      (detect-coding-string title t)
+                                      t))
          (title-faces (elfeed-search--faces (elfeed-entry-tags entry)))
          (feed (elfeed-entry-feed entry))
          (feed-title

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -146,6 +146,9 @@ Called without arguments."
   (interactive)
   (let* ((inhibit-read-only t)
          (title (elfeed-entry-title elfeed-show-entry))
+         (title (decode-coding-string title
+                                      (detect-coding-string title t)
+                                      t))
          (date (seconds-to-time (elfeed-entry-date elfeed-show-entry)))
          (authors (elfeed-meta elfeed-show-entry :authors))
          (link (elfeed-entry-link elfeed-show-entry))
@@ -211,12 +214,15 @@ The result depends on the value of `elfeed-show-unique-buffers'."
 
 (defun elfeed-show-entry (entry)
   "Display ENTRY in the current buffer."
-  (let ((buff (get-buffer-create (elfeed-show--buffer-name entry))))
-    (with-current-buffer buff
+  (let* ((buffer-title (elfeed-show--buffer-name entry))
+         (buffer (get-buffer-create (decode-coding-string buffer-title
+                                      (detect-coding-string buffer-title t)
+                                      t))))
+    (with-current-buffer buffer
       (elfeed-show-mode)
       (setq elfeed-show-entry entry)
       (elfeed-show-refresh))
-    (funcall elfeed-show-entry-switch buff)))
+    (funcall elfeed-show-entry-switch buffer)))
 
 (defun elfeed-show-next ()
   "Show the next item in the elfeed-search buffer."
@@ -486,9 +492,12 @@ Prompts for ENCLOSURE-INDEX when called interactively."
 
 (defun elfeed-show-bookmark-make-record ()
   "Save the current position and the entry into a bookmark."
-  (let ((id (elfeed-entry-id elfeed-show-entry))
+  (let* ((id (elfeed-entry-id elfeed-show-entry))
         (position (point))
-        (title (elfeed-entry-title elfeed-show-entry)))
+        (title (elfeed-entry-title elfeed-show-entry))
+        (title (decode-coding-string title
+                                      (detect-coding-string title t)
+                                      t)))
     `(,(format "elfeed entry \"%s\"" title)
       (id . ,id)
       (location . ,title)

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -117,7 +117,7 @@ Called without arguments."
       (setq content (format "%s[...]%s"
                             (substring content 0 len)
                             (substring content (- len))))))
-  (elfeed-insert-html (format "<a href=\"%s\">%s</a>" url content)))
+  (shr-tag-a `(a ((href . ,url))  ,content)))
 
 (defun elfeed-compute-base (url)
   "Return the base URL for URL, useful for relative paths."

--- a/elfeed.el
+++ b/elfeed.el
@@ -561,15 +561,17 @@ called interactively, SAVE is set to t."
 ;; New entry filtering
 
 (cl-defun elfeed-make-tagger
-    (&key feed-title feed-url entry-title entry-link after before
+    (&key feed-title feed-url feed-author entry-title entry-link
+          entry-enclosure entry-content-type after before
           add remove callback)
-  "Create a function that adds or removes tags on matching entries.
+  "Create a function that adds, removes tags or does CALLBACK on matching entries.
 
-FEED-TITLE, FEED-URL, ENTRY-TITLE, and ENTRY-LINK are regular
-expressions or a list (not <regex>), which indicates a negative
-match. AFTER and BEFORE are relative times (see
-`elfeed-time-duration'). Entries must match all provided
-expressions. If an entry matches, add tags ADD and remove tags
+FEED-TITLE, FEED-URL, FEED-AUTHOR, ENTRY-TITLE, ENTRY-LINK,
+ENTRY-ENCLOSURE and ENTRY-CONTENT-TYPE
+are regular expressions or a list \(not <regex>\),
+which indicates a negative match.  AFTER and BEFORE are relative times
+\(see `elfeed-time-duration'\).  Entries must match all provided
+expressions.  If an entry matches, add tags ADD and remove tags
 REMOVE.
 
 Examples,
@@ -601,8 +603,11 @@ The returned function should be added to `elfeed-new-entry-hook'."
           (when (and
                  (match feed-title  (elfeed-feed-title  feed))
                  (match feed-url    (elfeed-feed-url    feed))
+                 (match feed-author (elfeed-feed-author feed))
                  (match entry-title (elfeed-entry-title entry))
                  (match entry-link  (elfeed-entry-link  entry))
+                 (match entry-content-type (elfeed-entry-content-type entry))
+                 (match entry-enclosure (elfeed-entry-enclosures entry))
                  (or (not after-time)  (> date (- (float-time) after-time)))
                  (or (not before-time) (< date (- (float-time) before-time))))
             (when add

--- a/elfeed.el
+++ b/elfeed.el
@@ -563,13 +563,16 @@ called interactively, SAVE is set to t."
 (cl-defun elfeed-make-tagger
     (&key feed-title feed-url feed-author entry-title entry-link
           entry-enclosure entry-content-type after before
-          add remove callback)
+          feed-meta entry-meta add remove callback)
   "Create a function that adds, removes tags or does CALLBACK on matching entries.
 
 FEED-TITLE, FEED-URL, FEED-AUTHOR, ENTRY-TITLE, ENTRY-LINK,
-ENTRY-ENCLOSURE and ENTRY-CONTENT-TYPE
+ENTRY-ENCLOSURE, ENTRY-CONTENT-TYPE
 are regular expressions or a list \(not <regex>\),
-which indicates a negative match.  AFTER and BEFORE are relative times
+which indicates a negative match.  FEED-META and ENTRY-META are
+a list of key and value where car is the key and cadr is value.
+The key and value are matched against the respective meta's.
+AFTER and BEFORE are relative times
 \(see `elfeed-time-duration'\).  Entries must match all provided
 expressions.  If an entry matches, add tags ADD and remove tags
 REMOVE.
@@ -604,10 +607,12 @@ The returned function should be added to `elfeed-new-entry-hook'."
                  (match feed-title  (elfeed-feed-title  feed))
                  (match feed-url    (elfeed-feed-url    feed))
                  (match feed-author (elfeed-feed-author feed))
+                 (match (car feed-meta) (elfeed-meta feed (cadr feed-meta)))
                  (match entry-title (elfeed-entry-title entry))
                  (match entry-link  (elfeed-entry-link  entry))
                  (match entry-content-type (elfeed-entry-content-type entry))
                  (match entry-enclosure (elfeed-entry-enclosures entry))
+                 (match (car entry-meta) (elfeed-meta entry (cadr entry-meta)))
                  (or (not after-time)  (> date (- (float-time) after-time)))
                  (or (not before-time) (< date (- (float-time) before-time))))
             (when add

--- a/elfeed.el
+++ b/elfeed.el
@@ -554,8 +554,8 @@ called interactively, SAVE is set to t."
 (defun elfeed ()
   "Enter elfeed."
   (interactive)
-  (switch-to-buffer (elfeed-search-buffer))
-  (unless (eq major-mode 'elfeed-search-mode)
+  (display-buffer (elfeed-search-buffer))
+  (with-current-buffer (elfeed-search-buffer)
     (elfeed-search-mode)))
 
 ;; New entry filtering


### PR DESCRIPTION
shr-insert-contents opens a hole new buffer and dom paser. Simply
pass the S-expression to `shr-tag-a` which then only has to insert the
formatted link.

Also there's an easier way to check for libxml support with Emacs 27 and greater.

Includes my previous PR's.
Feel free to merge in any order.