### PR TITLE
Add link to elfeed-curate in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These projects extend Elfeed with additional features:
 * [elfeed-dashboard](https://github.com/Manoj321/elfeed-dashboard)
 * [elfeed-tube](https://github.com/karthink/elfeed-tube)
 * [elfeed-ai](https://github.com/benthamite/elfeed-ai)
+* [elfeed-curate](https://github.com/rnadler/elfeed-curate)
 
 ## Getting Started
 


### PR DESCRIPTION
Please add https://github.com/rnadler/elfeed-curate to the Elfeed extensions list. Thanks!