### PR TITLE
Add back elfeed-search-filter-face to filter

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -283,7 +283,8 @@ Movement is configured by `elfeed-search-remain-on-entry'."
       (concat
        (elfeed-search--header-button #'elfeed-update
                                      (concat "Updated " update))
-       ", " unread (and (not (equal filter "")) ", ") filter)))))
+       ", " unread (and (not (equal filter "")) ", ")
+       (propertize filter 'face 'elfeed-search-filter-face))))))
 
 (define-derived-mode elfeed-search-mode special-mode "elfeed-search"
   "Major mode for listing elfeed feed entries."


### PR DESCRIPTION
Hello minad.

I only noticed until today that the filter part of the elfeed header was missing its face. According to git, commit 3d66d7a was when this bug first appeared.

Or maybe it was intentional? In which case elfeed-search-filter-face should be removed.